### PR TITLE
Shapefile: add full binary (de)serialization support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Add github nuget source
       run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name "github.com" "https://nuget.pkg.github.com/sadicangel/index.json"
     - name: Restore dependencies

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="DBase" Version="0.1.0-preview.2" />
+    <PackageVersion Include="DBase" Version="0.1.0-preview.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit.v3" Version="1.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/src/Shape/Dimension.cs
+++ b/src/Shape/Dimension.cs
@@ -1,0 +1,19 @@
+﻿namespace Shape;
+
+public enum Dimension
+{
+    None,
+    Xy = 2,
+    Xym = 3,
+    Xyzm = 4,
+}
+
+internal static class DimensionExtensions
+{
+    extension(Dimension dimension)
+    {
+        public int PointByteSize => 8 * (int)dimension;
+
+        public int BoundingBoxSize => 2 * (int)dimension * dimension.PointByteSize;
+    }
+}

--- a/src/Shape/Geometries/BoundingBox.cs
+++ b/src/Shape/Geometries/BoundingBox.cs
@@ -20,6 +20,9 @@ public readonly record struct BoundingBox(Point Min, Point Max)
 
     public static BoundingBox FromPoints(IEnumerable<Point> points)
     {
+        using var enumerator = points.GetEnumerator();
+        if (!enumerator.MoveNext()) return Empty;
+
         var minX = double.MaxValue;
         var minY = double.MaxValue;
         var minZ = double.MaxValue;
@@ -28,17 +31,30 @@ public readonly record struct BoundingBox(Point Min, Point Max)
         var maxY = double.MinValue;
         var maxZ = double.MinValue;
         var maxM = double.MinValue;
-        foreach (var point in points)
+
+        var shapeType = enumerator.Current.ShapeType;
+        do
         {
-            minX = Math.Min(minX, point.X);
-            minY = Math.Min(minY, point.Y);
-            minZ = Math.Min(minZ, point.Z);
-            minM = Math.Min(minM, point.M);
-            maxX = Math.Max(maxX, point.X);
-            maxY = Math.Max(maxY, point.Y);
-            maxZ = Math.Max(maxZ, point.Z);
-            maxM = Math.Max(maxM, point.M);
-        }
-        return new BoundingBox(new Point(minX, minY, minZ, minM), new Point(maxX, maxY, maxZ, maxM));
+            // Assume all points have the same dimension.
+            var (_, x, y, z, m) = enumerator.Current;
+            minX = Math.Min(minX, x);
+            minY = Math.Min(minY, y);
+            minZ = Math.Min(minZ, z);
+            minM = Math.Min(minM, m);
+            maxX = Math.Max(maxX, x);
+            maxY = Math.Max(maxY, y);
+            maxZ = Math.Max(maxZ, z);
+            maxM = Math.Max(maxM, m);
+        } while (enumerator.MoveNext());
+
+        var (min, max) = shapeType switch
+        {
+            ShapeType.Point => (new Point(minX, minY), new Point(maxX, maxY)),
+            ShapeType.PointM => (new Point(minX, minY, minM), new Point(maxX, maxY, maxM)),
+            ShapeType.PointZ => (new Point(minX, minY, minZ, minM), new Point(maxX, maxY, maxZ, maxM)),
+            _ => throw new InvalidOperationException($"Invalid {nameof(Point)} {nameof(ShapeType)} '{shapeType}'")
+        };
+
+        return new BoundingBox(min, max);
     }
 }

--- a/src/Shape/Geometries/Geometry.cs
+++ b/src/Shape/Geometries/Geometry.cs
@@ -1,34 +1,6 @@
-﻿
-using System.Buffers.Binary;
+﻿namespace Shape.Geometries;
 
-namespace Shape.Geometries;
-
-public abstract record Geometry
+public abstract record Geometry(ShapeType ShapeType)
 {
-    internal const double MinValue = -10e38;
-    internal const double NoValue = -101e37;
-
     public abstract BoundingBox GetBoundingBox();
-
-    public static T Read<T>(ReadOnlySpan<byte> source) where T : Geometry, IGeometry<T> => T.Read(source);
-
-    public static Geometry Read(ReadOnlySpan<byte> source, ShapeType expectedShapeType)
-    {
-        var actualShapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
-
-        if (actualShapeType is not ShapeType.Null && actualShapeType != expectedShapeType)
-        {
-            throw new InvalidOperationException($"Shape type mismatch. Expected: {expectedShapeType}, Actual: {actualShapeType}");
-        }
-
-        return expectedShapeType switch
-        {
-            ShapeType.Point or ShapeType.PointZ or ShapeType.PointM => Read<Point>(source),
-            ShapeType.PolyLine or ShapeType.PolyLineZ or ShapeType.PolyLineM => Read<PolyLine>(source),
-            ShapeType.Polygon or ShapeType.PolygonZ or ShapeType.PolygonM => Read<Polygon>(source),
-            ShapeType.MultiPoint or ShapeType.MultiPointZ or ShapeType.MultiPointM => Read<MultiPoint>(source),
-            ShapeType.MultiPatch => Read<MultiPatch>(source),
-            _ => throw new InvalidOperationException($"Unknown shape type: {expectedShapeType}"),
-        };
-    }
 }

--- a/src/Shape/Geometries/IGeometry.cs
+++ b/src/Shape/Geometries/IGeometry.cs
@@ -1,8 +1,6 @@
 ﻿namespace Shape.Geometries;
 
-public interface IGeometry<T> where T : Geometry
+public interface IGeometry<out T> where T : Geometry
 {
-    abstract static T Empty { get; }
-
-    abstract static T Read(ReadOnlySpan<byte> source);
+    static abstract T Empty { get; }
 }

--- a/src/Shape/Geometries/LineString.cs
+++ b/src/Shape/Geometries/LineString.cs
@@ -9,16 +9,16 @@ public readonly record struct LineString(ImmutableArray<Point> Points) : IReadOn
 {
     public Point this[int index] => Points[index];
 
-    public int Count => Points.Length;
+    int IReadOnlyCollection<Point>.Count => Points.Length;
 
-    public IEnumerator<Point> GetEnumerator()
-    {
-        foreach (var point in Points)
-            yield return point;
-    }
+    public int Length => Points.Length;
+
+    public IEnumerator<Point> GetEnumerator() => ((IEnumerable<Point>)Points).GetEnumerator();
+
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public bool Equals(LineString other) => Points.SequenceEqual(other.Points);
+
     public override int GetHashCode()
     {
         var hash = new HashCode();

--- a/src/Shape/Geometries/LinearRing.cs
+++ b/src/Shape/Geometries/LinearRing.cs
@@ -9,16 +9,15 @@ public readonly record struct LinearRing(ImmutableArray<Point> Points) : IReadOn
 {
     public Point this[int index] => Points[index];
 
-    public int Count => Points.Length;
+    int IReadOnlyCollection<Point>.Count => Points.Length;
 
-    public IEnumerator<Point> GetEnumerator()
-    {
-        foreach (var point in Points)
-            yield return point;
-    }
+    public int Length => Points.Length;
+
+    public IEnumerator<Point> GetEnumerator() => ((IEnumerable<Point>)Points).GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public bool Equals(LinearRing other) => Points.SequenceEqual(other.Points);
+
     public override int GetHashCode()
     {
         var hash = new HashCode();

--- a/src/Shape/Geometries/MultiPatch.cs
+++ b/src/Shape/Geometries/MultiPatch.cs
@@ -1,11 +1,12 @@
-﻿using System.Buffers.Binary;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
+using Shape.Serialization;
 
 namespace Shape.Geometries;
 
-public sealed record class MultiPatch(ImmutableArray<Surface> Surfaces) : Geometry, IGeometry<MultiPatch>
+public sealed record class MultiPatch(ImmutableArray<Surface> Surfaces)
+    : Geometry(ShapeType.MultiPatch), IGeometry<MultiPatch>, IGeometrySerializer<MultiPatch>
 {
-    public static MultiPatch Empty { get; } = new MultiPatch([]);
+    public static MultiPatch Empty { get; } = new([]);
 
     public override BoundingBox GetBoundingBox() => BoundingBox.FromPoints(Surfaces.SelectMany(x => x));
 
@@ -19,44 +20,7 @@ public sealed record class MultiPatch(ImmutableArray<Surface> Surfaces) : Geomet
         return hash.ToHashCode();
     }
 
-    public static MultiPatch Read(ReadOnlySpan<byte> source)
-    {
-        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
-        if (shapeType is ShapeType.Null) return Empty;
-        var patchCount = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
-        var pointCount = BinaryPrimitives.ReadInt32LittleEndian(source[40..]);
-        var surfaces = ImmutableArray.CreateBuilder<Surface>(patchCount);
-
-        var tOffset = 44 + (patchCount * sizeof(int));
-        var xOffset = tOffset + (patchCount * sizeof(int));
-        var yOffset = xOffset + sizeof(double);
-        var zOffset = xOffset + 16 + (2 * pointCount * sizeof(double));
-        var mOffset = zOffset + 16 + (pointCount * sizeof(double));
-
-        var ringIndices = source[44..xOffset];
-
-        for (var i = 0; i < patchCount; ++i)
-        {
-            var start = BinaryPrimitives.ReadInt32LittleEndian(ringIndices[(i * sizeof(int))..]);
-            var end = i + 1 < patchCount
-                ? BinaryPrimitives.ReadInt32LittleEndian(ringIndices[((i + 1) * sizeof(int))..])
-                : pointCount;
-
-            var points = ImmutableArray.CreateBuilder<Point>(end - start);
-
-            while (start < end)
-            {
-                var x = BinaryPrimitives.ReadDoubleLittleEndian(source[(xOffset + start * 2 * sizeof(double))..]);
-                var y = BinaryPrimitives.ReadDoubleLittleEndian(source[(yOffset + start * 2 * sizeof(double))..]);
-                var z = BinaryPrimitives.ReadDoubleLittleEndian(source[(zOffset + (start * sizeof(double)))..]);
-                var m = BinaryPrimitives.ReadDoubleLittleEndian(source[(mOffset + (start * sizeof(double)))..]);
-                points.Add(new Point(x, y, z, m));
-                ++start;
-            }
-
-            var type = (SurfaceType)BinaryPrimitives.ReadInt32LittleEndian(source[(tOffset + start * sizeof(int))..]);
-            surfaces.Add(new Surface(type, points.MoveToImmutable()));
-        }
-        return new MultiPatch(surfaces.MoveToImmutable());
-    }
+    static int IGeometrySerializer<MultiPatch>.GetByteSize(MultiPatch geometry) => MultiPatchSerializer.GetByteSize(geometry);
+    static void IGeometrySerializer<MultiPatch>.Serialize(Span<byte> target, MultiPatch geometry) => MultiPatchSerializer.Serialize(target, geometry);
+    static MultiPatch IGeometrySerializer<MultiPatch>.Deserialize(ReadOnlySpan<byte> source) => MultiPatchSerializer.Deserialize(source);
 }

--- a/src/Shape/Geometries/MultiPoint.cs
+++ b/src/Shape/Geometries/MultiPoint.cs
@@ -1,12 +1,12 @@
-﻿using System.Buffers.Binary;
-using System.Collections.Immutable;
-using DotNext.Buffers;
+﻿using System.Collections.Immutable;
+using Shape.Serialization;
 
 namespace Shape.Geometries;
 
-public sealed record class MultiPoint(ImmutableArray<Point> Points) : Geometry, IGeometry<MultiPoint>, IEquatable<MultiPoint>
+public sealed record class MultiPoint(ImmutableArray<Point> Points)
+    : Geometry(GetShapeType(Points.FirstOrDefault())), IGeometry<MultiPoint>, IGeometrySerializer<MultiPoint>
 {
-    public static MultiPoint Empty { get; } = new MultiPoint([]);
+    public static MultiPoint Empty { get; } = new([]);
 
     public override BoundingBox GetBoundingBox() => BoundingBox.FromPoints(Points);
 
@@ -20,48 +20,18 @@ public sealed record class MultiPoint(ImmutableArray<Point> Points) : Geometry, 
         return hash.ToHashCode();
     }
 
-    public static MultiPoint Read(ReadOnlySpan<byte> source)
+    public static ShapeType GetShapeType(Point? referencePoint)
     {
-        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
-        if (shapeType is ShapeType.Null) return Empty;
-
-        var pointCount = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
-        using var memory = new SpanOwner<(double X, double Y, double Z, double M)>(pointCount);
-        var offset = 40;
-        for (var i = 0; i < pointCount; i += 2)
+        if (referencePoint is null) return ShapeType.Null;
+        return referencePoint switch
         {
-            memory.Span[i].X = BinaryPrimitives.ReadDoubleLittleEndian(source[offset..]);
-            offset += 8;
-            memory.Span[i].Y = BinaryPrimitives.ReadDoubleLittleEndian(source[offset..]);
-            offset += 8;
-            memory.Span[i].Z = NoValue;
-            memory.Span[i].M = NoValue;
-        }
-        if (shapeType is ShapeType.MultiPointZ or ShapeType.MultiPointM)
-        {
-            if (shapeType is ShapeType.MultiPointZ)
-            {
-                offset += 16;
-                for (var i = 0; i < pointCount; i += 2)
-                {
-                    memory.Span[i].Z = BinaryPrimitives.ReadDoubleLittleEndian(source[offset..]);
-                    offset += 8;
-                }
-            }
-
-            offset += 16;
-            for (var i = 0; i < pointCount; i += 2)
-            {
-                memory.Span[i].M = BinaryPrimitives.ReadDoubleLittleEndian(source[offset..]);
-                offset += 8;
-            }
-        }
-
-        var builder = ImmutableArray.CreateBuilder<Point>(pointCount);
-        for (var i = 0; i < pointCount; i += 2)
-        {
-            builder.Add(new Point(memory.Span[i].X, memory.Span[i].Y, memory.Span[i].Z, memory.Span[i].M));
-        }
-        return new MultiPoint(builder.MoveToImmutable());
+            { HasZ: true } => ShapeType.MultiPointZ,
+            { HasM: true } => ShapeType.MultiPointM,
+            _ => ShapeType.MultiPoint,
+        };
     }
+
+    static int IGeometrySerializer<MultiPoint>.GetByteSize(MultiPoint geometry) => MultiPointSerializer.GetByteSize(geometry);
+    static void IGeometrySerializer<MultiPoint>.Serialize(Span<byte> target, MultiPoint geometry) => MultiPointSerializer.Serialize(target, geometry);
+    static MultiPoint IGeometrySerializer<MultiPoint>.Deserialize(ReadOnlySpan<byte> source) => MultiPointSerializer.Deserialize(source);
 }

--- a/src/Shape/Geometries/Point.cs
+++ b/src/Shape/Geometries/Point.cs
@@ -1,41 +1,23 @@
-﻿
-using System.Buffers.Binary;
+﻿using Shape.Serialization;
 
 namespace Shape.Geometries;
 
-public sealed record class Point(double X, double Y, double Z, double M) : Geometry, IGeometry<Point>
+public sealed record class Point(ShapeType ShapeType, double X, double Y, double Z, double M)
+    : Geometry(ShapeType), IGeometry<Point>, IGeometrySerializer<Point>
 {
-    public static Point Empty { get; } = new Point(NoValue, NoValue, NoValue, NoValue);
+    public static Point Empty { get; } = new(ShapeType.Null, NumericLimits.NoValue, NumericLimits.NoValue, NumericLimits.NoValue, NumericLimits.NoValue);
 
-    public bool HasZ => Z > MinValue;
-    public bool HasM => M > MinValue;
+    public bool HasZ => Z > NumericLimits.MinValue;
+    public bool HasM => M > NumericLimits.MinValue;
 
-    public Point(double x, double y, double m) : this(x, y, NoValue, m) { }
+    public Point(double x, double y, double z, double m) : this(ShapeType.PointZ, x, y, z, m) { }
+    public Point(double x, double y, double m) : this(ShapeType.PointM, x, y, NumericLimits.NoValue, m) { }
 
-    public Point(double x, double y) : this(x, y, NoValue, NoValue) { }
+    public Point(double x, double y) : this(ShapeType.Point, x, y, NumericLimits.NoValue, NumericLimits.NoValue) { }
 
     public override BoundingBox GetBoundingBox() => new(this, this);
 
-    public static Point Read(ReadOnlySpan<byte> source)
-    {
-        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
-        return shapeType switch
-        {
-            ShapeType.Null => Empty,
-            ShapeType.Point => new Point(
-                BinaryPrimitives.ReadDoubleLittleEndian(source[4..]),
-                BinaryPrimitives.ReadDoubleLittleEndian(source[12..])),
-            ShapeType.PointZ => new Point(
-                BinaryPrimitives.ReadDoubleLittleEndian(source[4..]),
-                BinaryPrimitives.ReadDoubleLittleEndian(source[12..]),
-                BinaryPrimitives.ReadDoubleLittleEndian(source[20..]),
-                BinaryPrimitives.ReadDoubleLittleEndian(source[28..])),
-            ShapeType.PointM => new Point(
-                BinaryPrimitives.ReadDoubleLittleEndian(source[4..]),
-                BinaryPrimitives.ReadDoubleLittleEndian(source[12..]),
-                NoValue,
-                BinaryPrimitives.ReadDoubleLittleEndian(source[20..])),
-            _ => throw new InvalidOperationException($"Invalid shape type: {shapeType}. Expected: Point, PointZ, or PointM."),
-        };
-    }
+    static int IGeometrySerializer<Point>.GetByteSize(Point geometry) => PointSerializer.GetByteSize(geometry);
+    static void IGeometrySerializer<Point>.Serialize(Span<byte> target, Point geometry) => PointSerializer.Serialize(target, geometry);
+    static Point IGeometrySerializer<Point>.Deserialize(ReadOnlySpan<byte> source) => PointSerializer.Deserialize(source);
 }

--- a/src/Shape/Geometries/PolyLine.cs
+++ b/src/Shape/Geometries/PolyLine.cs
@@ -1,15 +1,17 @@
-﻿using System.Buffers.Binary;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
+using Shape.Serialization;
 
 namespace Shape.Geometries;
 
-public sealed record class PolyLine(ImmutableArray<LineString> Lines) : Geometry, IGeometry<PolyLine>
+public sealed record class PolyLine(ImmutableArray<LineString> Lines)
+    : Geometry(GetShapeType(Lines.SelectMany(x => x.Points).FirstOrDefault())), IGeometry<PolyLine>, IGeometrySerializer<PolyLine>
 {
     public static PolyLine Empty { get; } = new([[]]);
 
     public override BoundingBox GetBoundingBox() => BoundingBox.FromPoints(Lines.SelectMany(x => x));
 
     public bool Equals(PolyLine? other) => other is not null && Lines.SequenceEqual(other.Lines);
+
     public override int GetHashCode()
     {
         var hash = new HashCode();
@@ -18,48 +20,18 @@ public sealed record class PolyLine(ImmutableArray<LineString> Lines) : Geometry
         return hash.ToHashCode();
     }
 
-    public static PolyLine Read(ReadOnlySpan<byte> source)
+    public static ShapeType GetShapeType(Point? referencePoint)
     {
-        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
-        if (shapeType is ShapeType.Null) return Empty;
-        var stringCount = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
-        var pointCount = BinaryPrimitives.ReadInt32LittleEndian(source[40..]);
-        var lineStrings = ImmutableArray.CreateBuilder<LineString>(stringCount);
-
-        var xOffset = 44 + (stringCount * sizeof(int));
-        var yOffset = xOffset + sizeof(double);
-        var zOffset = xOffset + 16 + (2 * pointCount * sizeof(double));
-        var mOffset = shapeType is ShapeType.PolyLineM ? zOffset : zOffset + 16 + (pointCount * sizeof(double));
-
-        var ringIndices = source[44..xOffset];
-
-        for (var i = 0; i < stringCount; ++i)
+        if (referencePoint is null) return ShapeType.Null;
+        return referencePoint switch
         {
-            var start = BinaryPrimitives.ReadInt32LittleEndian(ringIndices[(i * sizeof(int))..]);
-            var end = i + 1 < stringCount
-                ? BinaryPrimitives.ReadInt32LittleEndian(ringIndices[((i + 1) * sizeof(int))..])
-                : pointCount;
-
-            var points = ImmutableArray.CreateBuilder<Point>(end - start);
-
-            while (start < end)
-            {
-                var x = BinaryPrimitives.ReadDoubleLittleEndian(source[(xOffset + start * 2 * sizeof(double))..]);
-                var y = BinaryPrimitives.ReadDoubleLittleEndian(source[(yOffset + start * 2 * sizeof(double))..]);
-                var z = NoValue;
-                var m = NoValue;
-                if (shapeType is ShapeType.PolyLineZ or ShapeType.PolyLineM)
-                {
-                    if (shapeType is ShapeType.PolyLineZ)
-                        z = BinaryPrimitives.ReadDoubleLittleEndian(source[(zOffset + (start * sizeof(double)))..]);
-                    m = BinaryPrimitives.ReadDoubleLittleEndian(source[(mOffset + (start * sizeof(double)))..]);
-                }
-                points.Add(new Point(x, y, z, m));
-                ++start;
-            }
-
-            lineStrings.Add(new LineString(points.MoveToImmutable()));
-        }
-        return new PolyLine(lineStrings.MoveToImmutable());
+            { HasZ: true } => ShapeType.PolyLineZ,
+            { HasM: true } => ShapeType.PolyLineM,
+            _ => ShapeType.PolyLine,
+        };
     }
+
+    static int IGeometrySerializer<PolyLine>.GetByteSize(PolyLine geometry) => PolyLineSerializer.GetByteSize(geometry);
+    static void IGeometrySerializer<PolyLine>.Serialize(Span<byte> target, PolyLine geometry) => PolyLineSerializer.Serialize(target, geometry);
+    static PolyLine IGeometrySerializer<PolyLine>.Deserialize(ReadOnlySpan<byte> source) => PolyLineSerializer.Deserialize(source);
 }

--- a/src/Shape/Geometries/Polygon.cs
+++ b/src/Shape/Geometries/Polygon.cs
@@ -1,19 +1,27 @@
-﻿using System.Buffers.Binary;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
+using Shape.Serialization;
 
 namespace Shape.Geometries;
 
-
-
-public sealed record class Polygon(ImmutableArray<LinearRing> Rings) : Geometry, IGeometry<Polygon>
+public sealed record class Polygon : Geometry, IGeometry<Polygon>, IGeometrySerializer<Polygon>
 {
     public static Polygon Empty { get; } = new([[]]);
 
     public LinearRing ExteriorRing => Rings[0];
 
+    public ImmutableArray<LinearRing> Rings { get; init; }
+
+    public Polygon(ImmutableArray<LinearRing> rings) : base(GetShapeType(rings.SelectMany(x => x.Points).FirstOrDefault()))
+    {
+        Rings = rings.Length > 0
+            ? rings
+            : throw new ArgumentException("At least one ring is required.", nameof(rings));
+    }
+
     public override BoundingBox GetBoundingBox() => BoundingBox.FromPoints(Rings.SelectMany(x => x));
 
     public bool Equals(Polygon? other) => other is not null && Rings.SequenceEqual(other.Rings);
+
     public override int GetHashCode()
     {
         var hash = new HashCode();
@@ -22,48 +30,18 @@ public sealed record class Polygon(ImmutableArray<LinearRing> Rings) : Geometry,
         return hash.ToHashCode();
     }
 
-    public static Polygon Read(ReadOnlySpan<byte> source)
+    public static ShapeType GetShapeType(Point? referencePoint)
     {
-        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
-        if (shapeType is ShapeType.Null) return Empty;
-        var ringCount = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
-        var pointCount = BinaryPrimitives.ReadInt32LittleEndian(source[40..]);
-        var linearRings = ImmutableArray.CreateBuilder<LinearRing>(ringCount);
-
-        var xOffset = 44 + (ringCount * sizeof(int));
-        var yOffset = xOffset + sizeof(double);
-        var zOffset = xOffset + 16 + (2 * pointCount * sizeof(double));
-        var mOffset = shapeType is ShapeType.PolygonM ? zOffset : zOffset + 16 + (pointCount * sizeof(double));
-
-        var ringIndices = source[44..xOffset];
-
-        for (var i = 0; i < ringCount; ++i)
+        if (referencePoint is null) return ShapeType.Null;
+        return referencePoint switch
         {
-            var start = BinaryPrimitives.ReadInt32LittleEndian(ringIndices[(i * sizeof(int))..]);
-            var end = i + 1 < ringCount
-                ? BinaryPrimitives.ReadInt32LittleEndian(ringIndices[((i + 1) * sizeof(int))..])
-                : pointCount;
-
-            var points = ImmutableArray.CreateBuilder<Point>(end - start);
-
-            while (start < end)
-            {
-                var x = BinaryPrimitives.ReadDoubleLittleEndian(source[(xOffset + start * 2 * sizeof(double))..]);
-                var y = BinaryPrimitives.ReadDoubleLittleEndian(source[(yOffset + start * 2 * sizeof(double))..]);
-                var z = NoValue;
-                var m = NoValue;
-                if (shapeType is ShapeType.PolygonZ or ShapeType.PolygonM)
-                {
-                    if (shapeType is ShapeType.PolygonZ)
-                        z = BinaryPrimitives.ReadDoubleLittleEndian(source[(zOffset + (start * sizeof(double)))..]);
-                    m = BinaryPrimitives.ReadDoubleLittleEndian(source[(mOffset + (start * sizeof(double)))..]);
-                }
-                points.Add(new Point(x, y, z, m));
-                ++start;
-            }
-
-            linearRings.Add(new LinearRing(points.MoveToImmutable()));
-        }
-        return new Polygon(linearRings.MoveToImmutable());
+            { HasZ: true } => ShapeType.PolygonZ,
+            { HasM: true } => ShapeType.PolygonM,
+            _ => ShapeType.Polygon,
+        };
     }
+
+    static int IGeometrySerializer<Polygon>.GetByteSize(Polygon geometry) => PolygonSerializer.GetByteSize(geometry);
+    static void IGeometrySerializer<Polygon>.Serialize(Span<byte> target, Polygon geometry) => PolygonSerializer.Serialize(target, geometry);
+    static Polygon IGeometrySerializer<Polygon>.Deserialize(ReadOnlySpan<byte> source) => PolygonSerializer.Deserialize(source);
 }

--- a/src/Shape/Geometries/Surface.cs
+++ b/src/Shape/Geometries/Surface.cs
@@ -6,14 +6,15 @@ namespace Shape.Geometries;
 public readonly record struct Surface(SurfaceType Type, ImmutableArray<Point> Points) : IReadOnlyList<Point>
 {
     public Point this[int index] => Points[index];
-    public int Count => Points.Length;
-    public IEnumerator<Point> GetEnumerator()
-    {
-        foreach (var point in Points)
-            yield return point;
-    }
+    int IReadOnlyCollection<Point>.Count => Points.Length;
+
+    public int Length => Points.Length;
+
+    public IEnumerator<Point> GetEnumerator() => ((IEnumerable<Point>)Points).GetEnumerator();
+
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     public bool Equals(Surface other) => Type == other.Type && Points.SequenceEqual(other.Points);
+
     public override int GetHashCode()
     {
         var hash = new HashCode();

--- a/src/Shape/IShapefile.cs
+++ b/src/Shape/IShapefile.cs
@@ -1,0 +1,19 @@
+﻿using DBase;
+using Shape.Geometries;
+
+namespace Shape;
+
+public interface IShapefile
+{
+    ShapeType ShapeType { get; }
+    int RecordCount { get; }
+
+    ShapeRecord<Geometry, DbfRecord> GetRecord(int index);
+
+    IEnumerator<ShapeRecord<Geometry, DbfRecord>> GetEnumerator()
+    {
+        var recordCount = RecordCount;
+        for (var i = 0; i < recordCount; ++i)
+            yield return GetRecord(i);
+    }
+}

--- a/src/Shape/NumericLimits.cs
+++ b/src/Shape/NumericLimits.cs
@@ -1,0 +1,7 @@
+﻿namespace Shape;
+
+internal static class NumericLimits
+{
+    public const double MinValue = -10e38;
+    public const double NoValue = -101e37;
+}

--- a/src/Shape/Serialization/BoundingBoxSerializer.cs
+++ b/src/Shape/Serialization/BoundingBoxSerializer.cs
@@ -1,0 +1,82 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal interface IBoundingBoxOffsets<T> where T : allows ref struct
+{
+    int ShapeType { get; }
+    int MinX { get; }
+    int MinY { get; }
+    int MaxX { get; }
+    int MaxY { get; }
+    int MinZ { get; }
+    int MaxZ { get; }
+    int MinM { get; }
+    int MaxM { get; }
+}
+
+internal static class BoundingBoxSerializer
+{
+    public static void Serialize<T>(Span<byte> target, T boundingBoxOffsets, Geometry geometry)
+        where T : IBoundingBoxOffsets<T>, allows ref struct
+    {
+        var o = boundingBoxOffsets;
+        var boundingBox = geometry.GetBoundingBox();
+        var shapeType = geometry.ShapeType;
+
+        BinaryPrimitives.WriteDoubleLittleEndian(target[o.MinX..], boundingBox.MinX);
+        BinaryPrimitives.WriteDoubleLittleEndian(target[o.MinY..], boundingBox.MinY);
+        BinaryPrimitives.WriteDoubleLittleEndian(target[o.MaxX..], boundingBox.MaxX);
+        BinaryPrimitives.WriteDoubleLittleEndian(target[o.MaxY..], boundingBox.MaxY);
+        if (shapeType.HasZ)
+        {
+            BinaryPrimitives.WriteDoubleLittleEndian(target[o.MinZ..], boundingBox.MinZ);
+            BinaryPrimitives.WriteDoubleLittleEndian(target[o.MaxZ..], boundingBox.MaxZ);
+        }
+
+        if (shapeType.HasM)
+        {
+            BinaryPrimitives.WriteDoubleLittleEndian(target[o.MinM..], boundingBox.MinM);
+            BinaryPrimitives.WriteDoubleLittleEndian(target[o.MaxM..], boundingBox.MaxM);
+        }
+    }
+
+    public static BoundingBox Deserialize<T>(ReadOnlySpan<byte> source, T boundingBoxOffsets)
+        where T : IBoundingBoxOffsets<T>, allows ref struct
+    {
+        var o = boundingBoxOffsets;
+        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source[o.ShapeType..]);
+
+        var minX = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MinX..]);
+        var minY = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MinY..]);
+        var maxX = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MaxX..]);
+        var maxY = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MaxY..]);
+
+        if (shapeType.HasZ)
+        {
+            var minZ = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MinZ..]);
+            var maxZ = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MaxZ..]);
+            var minM = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MinM..]);
+            var maxM = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MaxM..]);
+
+            return new BoundingBox(
+                Min: new Point(minX, minY, minZ, minM),
+                Max: new Point(maxX, maxY, maxZ, maxM));
+        }
+
+        if (shapeType.HasM)
+        {
+            var minM = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MinM..]);
+            var maxM = BinaryPrimitives.ReadDoubleLittleEndian(source[o.MaxM..]);
+
+            return new BoundingBox(
+                Min: new Point(minX, minY, minM),
+                Max: new Point(maxX, maxY, maxM));
+        }
+
+        return new BoundingBox(
+            Min: new Point(minX, minY),
+            Max: new Point(maxX, maxY));
+    }
+}

--- a/src/Shape/Serialization/GeometrySerializer.cs
+++ b/src/Shape/Serialization/GeometrySerializer.cs
@@ -1,0 +1,66 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+public interface IGeometrySerializer<TGeometry> where TGeometry : Geometry
+{
+    static abstract int GetByteSize(TGeometry geometry);
+    static abstract void Serialize(Span<byte> target, TGeometry geometry);
+    static abstract TGeometry Deserialize(ReadOnlySpan<byte> source);
+}
+
+public sealed class GeometrySerializer : IGeometrySerializer<Geometry>
+{
+    public static int GetByteSize(Geometry geometry)
+    {
+        return geometry switch
+        {
+            Point point => ByteSize<Point, PointSerializer>(point),
+            PolyLine polyLine => ByteSize<PolyLine, PolyLineSerializer>(polyLine),
+            Polygon polygon => ByteSize<Polygon, PolygonSerializer>(polygon),
+            MultiPoint multiPoint => ByteSize<MultiPoint, MultiPointSerializer>(multiPoint),
+            MultiPatch multiPatch => ByteSize<MultiPatch, MultiPatchSerializer>(multiPatch),
+            _ => throw new InvalidOperationException($"Unsupported geometry type: {geometry.GetType().Name}")
+        };
+    }
+
+    public static int ByteSize<TGeometry, TSerializer>(TGeometry geometry)
+        where TGeometry : Geometry
+        where TSerializer : IGeometrySerializer<TGeometry> =>
+        TSerializer.GetByteSize(geometry);
+
+    public static void Serialize(Span<byte> target, Geometry geometry)
+    {
+        switch (geometry)
+        {
+            case Point point: Serialize<Point, PointSerializer>(target, point); break;
+            case PolyLine polyLine: Serialize<PolyLine, PolyLineSerializer>(target, polyLine); break;
+            case Polygon polygon: Serialize<Polygon, PolygonSerializer>(target, polygon); break;
+            case MultiPoint multiPoint: Serialize<MultiPoint, MultiPointSerializer>(target, multiPoint); break;
+            case MultiPatch multiPatch: Serialize<MultiPatch, MultiPatchSerializer>(target, multiPatch); break;
+            default: throw new InvalidOperationException($"Unsupported geometry type: {geometry.GetType().Name}");
+        }
+    }
+
+    public static void Serialize<TGeometry, TSerializer>(Span<byte> target, TGeometry geometry) where TGeometry : Geometry where TSerializer : IGeometrySerializer<TGeometry> =>
+        TSerializer.Serialize(target, geometry);
+
+    public static Geometry Deserialize(ReadOnlySpan<byte> source)
+    {
+        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
+
+        return shapeType switch
+        {
+            ShapeType.Point or ShapeType.PointZ or ShapeType.PointM => Deserialize<Point, PointSerializer>(source),
+            ShapeType.PolyLine or ShapeType.PolyLineZ or ShapeType.PolyLineM => Deserialize<PolyLine, PolyLineSerializer>(source),
+            ShapeType.Polygon or ShapeType.PolygonZ or ShapeType.PolygonM => Deserialize<Polygon, PolygonSerializer>(source),
+            ShapeType.MultiPoint or ShapeType.MultiPointZ or ShapeType.MultiPointM => Deserialize<MultiPoint, MultiPointSerializer>(source),
+            ShapeType.MultiPatch => Deserialize<MultiPatch, MultiPatchSerializer>(source),
+            _ => throw new InvalidOperationException($"Unknown shape type: {shapeType}"),
+        };
+    }
+
+    public static TGeometry Deserialize<TGeometry, TSerializer>(ReadOnlySpan<byte> source) where TGeometry : Geometry where TSerializer : IGeometrySerializer<TGeometry> =>
+        TSerializer.Deserialize(source);
+}

--- a/src/Shape/Serialization/MultiPatchSerializer.cs
+++ b/src/Shape/Serialization/MultiPatchSerializer.cs
@@ -1,0 +1,149 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal sealed class MultiPatchSerializer : IGeometrySerializer<MultiPatch>
+{
+    /*
+     * ┌───────────┬────────────┬───────────┬─────────┬────────────┬────────────┐
+     * │ Position  │ Field      │ Value     │ Type    │ Count      │ Byte Order │
+     * ├───────────┼────────────┼───────────┼─────────┼────────────┼────────────┤
+     * │ Byte 0    │ ShapeType  │ 3|13|23   │ Int32   │ 1          │ Little     │
+     * │ Byte 4    │ Box        │ Box       │ Double  │ 4          │ Little     │
+     * │ Byte 36   │ NumParts   │ NumParts  │ Int32   │ 1          │ Little     │
+     * │ Byte 40   │ NumPoints  │ NumPoints │ Int32   │ 1          │ Little     │
+     * │ Byte 44   │ Parts      │ Parts     │ Int32   │ NumParts   │ Little     │
+     * │ Byte W    │ PartTypes  │ PartTypes │ Int32   │ NumParts   │ Little     │
+     * │ Byte X    │ Points     │ Points    │ Point   │ NumPoints  │ Little     │
+     * │ Byte Y*   │ Z|M min    │ Z|M min   │ Double  │ 1          │ Little     │
+     * │ Byte Y+8* │ Z|M max    │ Z|M max   │ Double  │ 1          │ Little     │
+     * │ Byte Y+16*│ Z|M Array  │ Z|M Array │ Double  │ NumPoints  │ Little     │
+     * │ Byte Z*   │ M min      │ M min     │ Double  │ 1          │ Little     │
+     * │ Byte Z+8* │ M max      │ M max     │ Double  │ 1          │ Little     │
+     * │ Byte Z+16*│ M Array    │ M Array   │ Double  │ NumPoints  │ Little     │
+     * └───────────┴────────────┴───────────┴─────────┴────────────┴────────────┘
+     *
+     * Notes:
+     *   W = 44 + (4  * NumParts)
+     *   X = W + (4  * NumParts)
+     *   Y = X  + (16 * NumPoints)
+     *   Z = Y  + 16 + (8 * NumPoints)
+     *
+     *   (*) optional.
+     */
+
+    private readonly ref struct MultiPatchOffsets : IBoundingBoxOffsets<MultiPatchOffsets>, IPartArrayOffsets<MultiPatchOffsets>
+    {
+        public int ShapeType { get; }
+        public int MinX { get; }
+        public int MinY { get; }
+        public int MaxX { get; }
+        public int MaxY { get; }
+        public int NumParts { get; }
+        public int NumPoints { get; }
+        public int Parts { get; }
+        public int PartTypes { get; }
+        public int Points { get; }
+        public int MinZ { get; }
+        public int MaxZ { get; }
+        public int ZArray { get; }
+        public int MinM { get; }
+        public int MaxM { get; }
+        public int MArray { get; }
+
+        private MultiPatchOffsets(ShapeType shapeType, int numParts, int numPoints)
+        {
+            ShapeType = 0;
+            if (shapeType is Shape.ShapeType.Null) return;
+
+            var w = 44 + 4 * numParts;
+            var x = w + 4 * numParts;
+            var y = x + 16 * numPoints;
+            var z = y + 16 + 8 * numPoints;
+
+            MinX = 4;
+            MinY = 12;
+            MaxX = 20;
+            MaxY = 28;
+            NumParts = 36;
+            NumPoints = 40;
+            Parts = 44;
+            PartTypes = w;
+            Points = x;
+            MinZ = y;
+            MaxZ = y + 8;
+            ZArray = y + 16;
+
+            MinM = z;
+            MaxM = z + 8;
+            MArray = z + 16;
+        }
+
+        public MultiPatchOffsets(MultiPatch multiPatch) : this(
+            shapeType: multiPatch.ShapeType,
+            numParts: multiPatch.Surfaces.Length,
+            numPoints: multiPatch.Surfaces.Sum(s => s.Points.Length))
+        { }
+
+        public static MultiPatchOffsets Detect(ReadOnlySpan<byte> source)
+        {
+            var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
+            if (shapeType is Shape.ShapeType.Null)
+            {
+                return new MultiPatchOffsets(shapeType, 0, 0);
+            }
+
+            shapeType.EnsureCompatibleWith<MultiPatch>();
+
+            var numParts = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
+            var numPoints = BinaryPrimitives.ReadInt32LittleEndian(source[40..]);
+            return new MultiPatchOffsets(shapeType, numParts, numPoints);
+        }
+    }
+
+    public static int GetByteSize(MultiPatch geometry)
+    {
+        if (geometry.ShapeType is ShapeType.Null) return 4 /* ShapeType */;
+
+        var dimension = geometry.ShapeType.Dimension;
+        return
+            4 /* ShapeType */ +
+            dimension.BoundingBoxSize +
+            4 /* NumParts */ +
+            4 /* NumPoints */ +
+            geometry.Surfaces.Length * 4 /* Parts */ +
+            geometry.Surfaces.Length * 4 /* PartTypes */ +
+            geometry.Surfaces.Sum(x => x.Length) * dimension.PointByteSize /* Points */;
+    }
+
+    public static void Serialize(Span<byte> target, MultiPatch multiPatch)
+    {
+        var offsets = new MultiPatchOffsets(multiPatch);
+        ShapeTypeSerializer.Serialize(target, offsets, multiPatch);
+        BoundingBoxSerializer.Serialize(target, offsets, multiPatch);
+        if (multiPatch.ShapeType is ShapeType.Null) return;
+
+        for (var i = 0; i < multiPatch.Surfaces.Length; i++)
+            BinaryPrimitives.WriteInt32LittleEndian(target[(offsets.PartTypes + i * 4)..], (int)multiPatch.Surfaces[i].Type);
+
+        PartArraySerializer.Serialize(target, offsets, multiPatch.ShapeType, multiPatch.Surfaces);
+    }
+
+    public static MultiPatch Deserialize(ReadOnlySpan<byte> source)
+    {
+        var offsets = MultiPatchOffsets.Detect(source);
+        var shapeType = ShapeTypeSerializer.Deserialize(source, offsets);
+        if (shapeType is ShapeType.Null) return MultiPatch.Empty;
+
+        var numParts = BinaryPrimitives.ReadInt32LittleEndian(source[offsets.NumParts..]);
+        var partTypes = new SurfaceType[numParts];
+        for (var i = 0; i < numParts; i++)
+        {
+            partTypes[i] = (SurfaceType)BinaryPrimitives.ReadInt32LittleEndian(source[(offsets.PartTypes + i * 4)..]);
+        }
+
+        var surfaces = PartArraySerializer.Deserialize(source, offsets, (index, points) => new Surface(partTypes[index], points));
+        return new MultiPatch(surfaces);
+    }
+}

--- a/src/Shape/Serialization/MultiPointSerializer.cs
+++ b/src/Shape/Serialization/MultiPointSerializer.cs
@@ -1,0 +1,118 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal sealed class MultiPointSerializer : IGeometrySerializer<MultiPoint>
+{
+    /*
+     * ┌───────────┬────────────┬───────────┬─────────┬────────────┬────────────┐
+     * │ Position  │ Field      │ Value     │ Type    │ Count      │ Byte Order │
+     * ├───────────┼────────────┼───────────┼─────────┼────────────┼────────────┤
+     * │ Byte 0    │ ShapeType  │ 8|18|28   │ Int32   │ 1          │ Little     │
+     * │ Byte 4    │ Box        │ Box       │ Double  │ 4          │ Little     │
+     * │ Byte 36   │ NumPoints  │ NumPoints │ Int32   │ 1          │ Little     │
+     * │ Byte 40   │ Points     │ Points    │ Point   │ NumPoints  │ Little     │
+     * │ Byte X*   │ Z|M min    │ Z|M min   │ Double  │ 1          │ Little     │
+     * │ Byte Y+8* │ Z|M max    │ Z|M max   │ Double  │ 1          │ Little     │
+     * │ Byte Y+16*│ Z|M Array  │ Z|M Array │ Double  │ NumPoints  │ Little     │
+     * │ Byte Y*   │ M min      │ M min     │ Double  │ 1          │ Little     │
+     * │ Byte Y+8* │ M max      │ M max     │ Double  │ 1          │ Little     │
+     * │ Byte Y+16*│ M Array    │ M Array   │ Double  │ NumPoints  │ Little     │
+     * └───────────┴────────────┴───────────┴─────────┴────────────┴────────────┘
+     *
+     * Notes:
+     *   X = 40  + (16 * NumPoints)
+     *   Y = X  + 16 + (8 * NumPoints)
+     *
+     *   (*) optional.
+     */
+
+    private readonly ref struct MultiPointOffsets : IBoundingBoxOffsets<MultiPointOffsets>, IPointArrayOffsets<MultiPointOffsets>
+    {
+        public int ShapeType { get; }
+        public int MinX { get; }
+        public int MinY { get; }
+        public int MaxX { get; }
+        public int MaxY { get; }
+        public int NumPoints { get; }
+        public int Points { get; }
+        public int MinZ { get; }
+        public int MaxZ { get; }
+        public int ZArray { get; }
+        public int MinM { get; }
+        public int MaxM { get; }
+        public int MArray { get; }
+
+        private MultiPointOffsets(ShapeType shapeType, int numPoints)
+        {
+            ShapeType = 0;
+            if (shapeType is Shape.ShapeType.Null) return;
+
+            MinX = 4;
+            MinY = 12;
+            MaxX = 20;
+            MaxY = 28;
+            NumPoints = 36;
+            Points = 40;
+            if (shapeType is Shape.ShapeType.MultiPoint) return;
+
+            var x = 40 + 16 * numPoints;
+            var y = x + 16 + 8 * numPoints;
+            MinZ = x;
+            MaxZ = x + 8;
+            ZArray = x + 16;
+            if (shapeType is Shape.ShapeType.MultiPointM) y = x;
+
+            MinM = y;
+            MaxM = y + 8;
+            MArray = y + 16;
+        }
+
+        public MultiPointOffsets(MultiPoint multiPoint) : this(multiPoint.ShapeType, multiPoint.Points.Length) { }
+
+        public static MultiPointOffsets Detect(ReadOnlySpan<byte> source)
+        {
+            var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
+            if (shapeType is Shape.ShapeType.Null)
+            {
+                return new MultiPointOffsets(shapeType, 0);
+            }
+
+            shapeType.EnsureCompatibleWith<MultiPoint>();
+
+            var numPoints = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
+            return new MultiPointOffsets(shapeType, numPoints);
+        }
+    }
+
+    public static int GetByteSize(MultiPoint geometry)
+    {
+        if (geometry.ShapeType is ShapeType.Null) return 4 /* ShapeType */;
+
+        var dimension = geometry.ShapeType.Dimension;
+        return
+            4 /* ShapeType */ +
+            dimension.BoundingBoxSize +
+            4 /* NumPoints */ +
+            geometry.Points.Length * dimension.PointByteSize;
+    }
+
+    public static void Serialize(Span<byte> target, MultiPoint multiPoint)
+    {
+        var offsets = new MultiPointOffsets(multiPoint);
+        ShapeTypeSerializer.Serialize(target, offsets, multiPoint);
+        BoundingBoxSerializer.Serialize(target, offsets, multiPoint);
+        PointArraySerializer.Serialize(target, offsets, multiPoint.ShapeType, multiPoint.Points);
+    }
+
+    public static MultiPoint Deserialize(ReadOnlySpan<byte> source)
+    {
+        var offsets = MultiPointOffsets.Detect(source);
+        var shapeType = ShapeTypeSerializer.Deserialize(source, offsets);
+        if (shapeType is ShapeType.Null) return MultiPoint.Empty;
+
+        var points = PointArraySerializer.Deserialize(source, offsets);
+        return new MultiPoint(points);
+    }
+}

--- a/src/Shape/Serialization/PartArraySerializer.cs
+++ b/src/Shape/Serialization/PartArraySerializer.cs
@@ -1,0 +1,122 @@
+﻿using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal interface IPartArrayOffsets<T> : IShapeTypeOffsets<T> where T : allows ref struct
+{
+    int NumParts { get; }
+    int NumPoints { get; }
+    int Parts { get; }
+    int Points { get; }
+    int ZArray { get; }
+    int MArray { get; }
+}
+
+internal static class PartArraySerializer
+{
+    public static void Serialize<TOffsets, TPart>(Span<byte> target, TOffsets pointsOffset, ShapeType shapeType, IReadOnlyList<TPart> parts)
+        where TOffsets : IPartArrayOffsets<TOffsets>, allows ref struct
+        where TPart : IReadOnlyList<Point>
+    {
+        var o = pointsOffset;
+        BinaryPrimitives.WriteInt32LittleEndian(target[o.NumParts..], parts.Count);
+        BinaryPrimitives.WriteInt32LittleEndian(target[o.NumPoints..], parts.Sum(ls => ls.Count));
+        var partIndex = 0;
+        for (var i = 0; i < parts.Count; i++)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(target[(o.Parts + i * sizeof(int))..], partIndex);
+            partIndex += parts[i].Count;
+        }
+
+        var j = 0;
+        foreach (var point in parts.SelectMany(part => part))
+        {
+            BinaryPrimitives.WriteDoubleLittleEndian(target[(o.Points + j * 16)..], point.X);
+            BinaryPrimitives.WriteDoubleLittleEndian(target[(o.Points + j * 16 + 8)..], point.Y);
+            if (shapeType.HasZ) BinaryPrimitives.WriteDoubleLittleEndian(target[(o.ZArray + j * 8)..], point.Z);
+            if (shapeType.HasM) BinaryPrimitives.WriteDoubleLittleEndian(target[(o.MArray + j * 8)..], point.M);
+            j++;
+        }
+    }
+
+    public static ImmutableArray<TPart> Deserialize<TOffsets, TPart>(ReadOnlySpan<byte> source, TOffsets pointArrayOffsets, Func<int, ImmutableArray<Point>, TPart> factory)
+        where TOffsets : IPartArrayOffsets<TOffsets>, allows ref struct
+        where TPart : IReadOnlyList<Point>
+    {
+        var o = pointArrayOffsets;
+        var shapeType = ShapeTypeSerializer.Deserialize(source, o);
+        var numParts = BinaryPrimitives.ReadInt32LittleEndian(source[o.NumParts..]);
+        var numPoints = BinaryPrimitives.ReadInt32LittleEndian(source[o.NumPoints..]);
+
+        var parts = ImmutableArray.CreateBuilder<TPart>(numParts);
+        var lengths = GetLengths(source, o.Parts, numParts, numPoints);
+        var partIndex = 0;
+        var pointIndex = 0;
+        foreach (var length in lengths)
+        {
+            var points = ImmutableArray.CreateBuilder<Point>(length);
+            for (var i = 0; i < length; i++, pointIndex++)
+            {
+                var x = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.Points + pointIndex * 16)..]);
+                var y = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.Points + pointIndex * 16 + 8)..]);
+                switch (shapeType.Dimension)
+                {
+                    case Dimension.Xyzm:
+                        {
+                            var z = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.ZArray + pointIndex * 8)..]);
+                            var m = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.MArray + pointIndex * 8)..]);
+
+                            points.Add(new Point(x, y, z, m));
+                        }
+                        break;
+
+                    case Dimension.Xym:
+                        {
+                            var m = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.MArray + pointIndex * 8)..]);
+                            points.Add(new Point(x, y, m));
+                        }
+                        break;
+
+                    case Dimension.Xy:
+                        {
+                            points.Add(new Point(x, y));
+                        }
+                        break;
+
+                    default:
+                        throw new UnreachableException($"{nameof(Dimension)} '{shapeType.Dimension}' is invalid");
+                }
+            }
+
+            parts.Add(factory.Invoke(partIndex++, points.MoveToImmutable()));
+        }
+
+        return parts.MoveToImmutable();
+
+        static int[] GetLengths(
+            ReadOnlySpan<byte> source,
+            int partsOffset,
+            int numParts,
+            int numPoints)
+        {
+            var lengths = new int[numParts];
+            var previous = BinaryPrimitives.ReadInt32LittleEndian(source.Slice(partsOffset, sizeof(int)));
+
+            for (var i = 1; i < numParts; i++)
+            {
+                var current = BinaryPrimitives.ReadInt32LittleEndian(source.Slice(partsOffset + i * sizeof(int), sizeof(int)));
+
+                lengths[i - 1] = current - previous;
+                previous = current;
+            }
+
+            // Last part ends at numPoints
+            lengths[numParts - 1] = numPoints - previous;
+
+            return lengths;
+        }
+    }
+}

--- a/src/Shape/Serialization/PointArraySerializer.cs
+++ b/src/Shape/Serialization/PointArraySerializer.cs
@@ -1,0 +1,78 @@
+﻿using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal interface IPointArrayOffsets<T> : IShapeTypeOffsets<T> where T : allows ref struct
+{
+    int NumPoints { get; }
+    int Points { get; }
+    int ZArray { get; }
+    int MArray { get; }
+}
+
+internal static class PointArraySerializer
+{
+    public static void Serialize<TOffsets>(Span<byte> target, TOffsets pointsOffset, ShapeType shapeType, IReadOnlyList<Point> points)
+        where TOffsets : IPointArrayOffsets<TOffsets>, allows ref struct
+    {
+        var o = pointsOffset;
+        BinaryPrimitives.WriteInt32LittleEndian(target[o.NumPoints..], points.Count);
+
+        var j = 0;
+        foreach (var point in points)
+        {
+            BinaryPrimitives.WriteDoubleLittleEndian(target[(o.Points + j * 16)..], point.X);
+            BinaryPrimitives.WriteDoubleLittleEndian(target[(o.Points + j * 16 + 8)..], point.Y);
+            if (shapeType.HasZ) BinaryPrimitives.WriteDoubleLittleEndian(target[(o.ZArray + j * 8)..], point.Z);
+            if (shapeType.HasM) BinaryPrimitives.WriteDoubleLittleEndian(target[(o.MArray + j * 8)..], point.M);
+            j++;
+        }
+    }
+
+    public static ImmutableArray<Point> Deserialize<TOffsets>(ReadOnlySpan<byte> source, TOffsets pointArrayOffsets)
+        where TOffsets : IPointArrayOffsets<TOffsets>, allows ref struct
+    {
+        var o = pointArrayOffsets;
+        var shapeType = ShapeTypeSerializer.Deserialize(source, o);
+        var numPoints = BinaryPrimitives.ReadInt32LittleEndian(source[o.NumPoints..]);
+
+        var points = ImmutableArray.CreateBuilder<Point>(numPoints);
+        for (var i = 0; i < numPoints; i++)
+        {
+            var x = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.Points + i * 16)..]);
+            var y = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.Points + i * 16 + 8)..]);
+            switch (shapeType.Dimension)
+            {
+                case Dimension.Xyzm:
+                    {
+                        var z = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.ZArray + i * 8)..]);
+                        var m = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.MArray + i * 8)..]);
+
+                        points.Add(new Point(x, y, z, m));
+                    }
+                    break;
+
+                case Dimension.Xym:
+                    {
+                        var m = BinaryPrimitives.ReadDoubleLittleEndian(source[(o.MArray + i * 8)..]);
+                        points.Add(new Point(x, y, m));
+                    }
+                    break;
+
+                case Dimension.Xy:
+                    {
+                        points.Add(new Point(x, y));
+                    }
+                    break;
+
+                default:
+                    throw new UnreachableException($"{nameof(Dimension)} '{shapeType.Dimension}' is invalid");
+            }
+        }
+
+        return points.MoveToImmutable();
+    }
+}

--- a/src/Shape/Serialization/PointSerializer.cs
+++ b/src/Shape/Serialization/PointSerializer.cs
@@ -1,0 +1,83 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+public sealed class PointSerializer : IGeometrySerializer<Point>
+{
+    /*
+     * ┌───────────┬────────────┬───────────┬─────────┬────────────┬────────────┐
+     * │ Position  │ Field      │ Value     │ Type    │ Count      │ Byte Order │
+     * ├───────────┼────────────┼───────────┼─────────┼────────────┼────────────┤
+     * │ Byte 0    │ ShapeType  │ 1|11|21   │ Int32   │ 1          │ Little     │
+     * │ Byte 4    │ X          │ X         │ Double  │ 1          │ Little     │
+     * │ Byte 12   │ Y          │ Y         │ Double  │ 1          │ Little     │
+     * │ Byte 20*  │ Z|M        │ Z|M       │ Double  │ 1          │ Little     │
+     * │ Byte 28*  │ M          │ M         │ Double  │ 1          │ Little     │
+     * └───────────┴────────────┴───────────┴─────────┴────────────┴────────────┘
+     *
+     * Notes:
+     *   (*) optional.
+     */
+
+    private readonly ref struct PointOffsets : IShapeTypeOffsets<PointOffsets>
+    {
+        public int ShapeType { get; }
+        public int X { get; }
+        public int Y { get; }
+        public int Z { get; }
+        public int M { get; }
+
+        private PointOffsets(ShapeType shapeType)
+        {
+            ShapeType = 0;
+            if (shapeType is Shape.ShapeType.Null) return;
+            X = 4;
+            Y = 12;
+            if (shapeType is Shape.ShapeType.Point) return;
+            Z = 20;
+            M = 28;
+            if (shapeType is Shape.ShapeType.PointM) M = Z;
+        }
+
+        public PointOffsets(Point point) : this(point.ShapeType) { }
+
+        public static PointOffsets Detect(ReadOnlySpan<byte> source) => new((ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source));
+    }
+
+    public static int GetByteSize(Point geometry) => 4 /* ShapeType */ + geometry.ShapeType.Dimension.PointByteSize;
+
+    public static void Serialize(Span<byte> target, Point point)
+    {
+        var o = new PointOffsets(point);
+        BinaryPrimitives.WriteInt32LittleEndian(target[o.ShapeType..], (int)point.ShapeType);
+        if (point.ShapeType is ShapeType.Null) return;
+        BinaryPrimitives.WriteDoubleLittleEndian(target[o.X..], point.X);
+        BinaryPrimitives.WriteDoubleLittleEndian(target[o.Y..], point.Y);
+        if (point.HasZ) BinaryPrimitives.WriteDoubleLittleEndian(target[o.Z..], point.Z);
+        if (point.HasM) BinaryPrimitives.WriteDoubleLittleEndian(target[o.M..], point.M);
+    }
+
+    public static Point Deserialize(ReadOnlySpan<byte> source)
+    {
+        var o = PointOffsets.Detect(source);
+        var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
+        return shapeType switch
+        {
+            ShapeType.Null => Point.Empty,
+            ShapeType.Point => new Point(
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.X..]),
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.Y..])),
+            ShapeType.PointZ => new Point(
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.X..]),
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.Y..]),
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.Z..]),
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.M..])),
+            ShapeType.PointM => new Point(
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.X..]),
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.Y..]),
+                BinaryPrimitives.ReadDoubleLittleEndian(source[o.M..])),
+            _ => throw new InvalidOperationException($"Invalid shape type: {shapeType}. Expected: Point, PointZ, or PointM."),
+        };
+    }
+}

--- a/src/Shape/Serialization/PolyLineSerializer.cs
+++ b/src/Shape/Serialization/PolyLineSerializer.cs
@@ -1,0 +1,133 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal sealed class PolyLineSerializer : IGeometrySerializer<PolyLine>
+{
+    /*
+     * ┌───────────┬────────────┬───────────┬─────────┬────────────┬────────────┐
+     * │ Position  │ Field      │ Value     │ Type    │ Count      │ Byte Order │
+     * ├───────────┼────────────┼───────────┼─────────┼────────────┼────────────┤
+     * │ Byte 0    │ ShapeType  │ 3|13|23   │ Int32   │ 1          │ Little     │
+     * │ Byte 4    │ Box        │ Box       │ Double  │ 4          │ Little     │
+     * │ Byte 36   │ NumParts   │ NumParts  │ Int32   │ 1          │ Little     │
+     * │ Byte 40   │ NumPoints  │ NumPoints │ Int32   │ 1          │ Little     │
+     * │ Byte 44   │ Parts      │ Parts     │ Int32   │ NumParts   │ Little     │
+     * │ Byte X    │ Points     │ Points    │ Point   │ NumPoints  │ Little     │
+     * │ Byte Y*   │ Z|M min    │ Z|M min   │ Double  │ 1          │ Little     │
+     * │ Byte Y+8* │ Z|M max    │ Z|M max   │ Double  │ 1          │ Little     │
+     * │ Byte Y+16*│ Z|M Array  │ Z|M Array │ Double  │ NumPoints  │ Little     │
+     * │ Byte Z*   │ M min      │ M min     │ Double  │ 1          │ Little     │
+     * │ Byte Z+8* │ M max      │ M max     │ Double  │ 1          │ Little     │
+     * │ Byte Z+16*│ M Array    │ M Array   │ Double  │ NumPoints  │ Little     │
+     * └───────────┴────────────┴───────────┴─────────┴────────────┴────────────┘
+     *
+     * Notes:
+     *   X = 44 + (4  * NumParts)
+     *   Y = X  + (16 * NumPoints)
+     *   Z = Y  + 16 + (8 * NumPoints)
+     *
+     *   (*) optional.
+     */
+
+    private readonly ref struct PolyLineOffsets : IBoundingBoxOffsets<PolyLineOffsets>, IPartArrayOffsets<PolyLineOffsets>
+    {
+        public int ShapeType { get; }
+        public int MinX { get; }
+        public int MinY { get; }
+        public int MaxX { get; }
+        public int MaxY { get; }
+        public int NumParts { get; }
+        public int NumPoints { get; }
+        public int Parts { get; }
+        public int Points { get; }
+        public int MinZ { get; }
+        public int MaxZ { get; }
+        public int ZArray { get; }
+        public int MinM { get; }
+        public int MaxM { get; }
+        public int MArray { get; }
+
+        private PolyLineOffsets(ShapeType shapeType, int numParts, int numPoints)
+        {
+            ShapeType = 0;
+            if (shapeType is Shape.ShapeType.Null) return;
+
+            var x = 44 + 4 * numParts;
+            MinX = 4;
+            MinY = 12;
+            MaxX = 20;
+            MaxY = 28;
+            NumParts = 36;
+            NumPoints = 40;
+            Parts = 44;
+            Points = x;
+            if (shapeType is Shape.ShapeType.PolyLine) return;
+
+            var y = x + 16 * numPoints;
+            var z = y + 16 + 8 * numPoints;
+            MinZ = y;
+            MaxZ = y + 8;
+            ZArray = y + 16;
+            if (shapeType is Shape.ShapeType.PolyLineM) z = y;
+
+            MinM = z;
+            MaxM = z + 8;
+            MArray = z + 16;
+        }
+
+        public PolyLineOffsets(PolyLine polyLine) : this(
+            shapeType: polyLine.ShapeType,
+            numParts: polyLine.Lines.Length,
+            numPoints: polyLine.Lines.Sum(ls => ls.Length))
+        { }
+
+        public static PolyLineOffsets Detect(ReadOnlySpan<byte> source)
+        {
+            var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
+            if (shapeType is Shape.ShapeType.Null)
+            {
+                return new PolyLineOffsets(shapeType, 0, 0);
+            }
+
+            shapeType.EnsureCompatibleWith<PolyLine>();
+
+            var numParts = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
+            var numPoints = BinaryPrimitives.ReadInt32LittleEndian(source[40..]);
+            return new PolyLineOffsets(shapeType, numParts, numPoints);
+        }
+    }
+
+    public static int GetByteSize(PolyLine geometry)
+    {
+        if (geometry.ShapeType is ShapeType.Null) return 4 /* ShapeType */;
+
+        var dimension = geometry.ShapeType.Dimension;
+        return
+            4 /* ShapeType */ +
+            dimension.BoundingBoxSize +
+            4 /* NumParts */ +
+            4 /* NumPoints */ +
+            geometry.Lines.Length * 4 /* Parts */ +
+            geometry.Lines.Sum(x => x.Length) * dimension.PointByteSize /* Points */;
+    }
+
+    public static void Serialize(Span<byte> target, PolyLine polyLine)
+    {
+        var offsets = new PolyLineOffsets(polyLine);
+        ShapeTypeSerializer.Serialize(target, offsets, polyLine);
+        if (polyLine.ShapeType is ShapeType.Null) return;
+        BoundingBoxSerializer.Serialize(target, offsets, polyLine);
+        PartArraySerializer.Serialize(target, offsets, polyLine.ShapeType, polyLine.Lines);
+    }
+
+    public static PolyLine Deserialize(ReadOnlySpan<byte> source)
+    {
+        var offsets = PolyLineOffsets.Detect(source);
+        var shapeType = ShapeTypeSerializer.Deserialize(source, offsets);
+        if (shapeType is ShapeType.Null) return PolyLine.Empty;
+        var lines = PartArraySerializer.Deserialize(source, offsets, (_, points) => new LineString(points));
+        return new PolyLine(lines);
+    }
+}

--- a/src/Shape/Serialization/PolygonSerializer.cs
+++ b/src/Shape/Serialization/PolygonSerializer.cs
@@ -1,0 +1,133 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal sealed class PolygonSerializer : IGeometrySerializer<Polygon>
+{
+    /*
+     * ┌───────────┬────────────┬───────────┬─────────┬────────────┬────────────┐
+     * │ Position  │ Field      │ Value     │ Type    │ Count      │ Byte Order │
+     * ├───────────┼────────────┼───────────┼─────────┼────────────┼────────────┤
+     * │ Byte 0    │ ShapeType  │ 5|15|25   │ Int32   │ 1          │ Little     │
+     * │ Byte 4    │ Box        │ Box       │ Double  │ 4          │ Little     │
+     * │ Byte 36   │ NumParts   │ NumParts  │ Int32   │ 1          │ Little     │
+     * │ Byte 40   │ NumPoints  │ NumPoints │ Int32   │ 1          │ Little     │
+     * │ Byte 44   │ Parts      │ Parts     │ Int32   │ NumParts   │ Little     │
+     * │ Byte X    │ Points     │ Points    │ Point   │ NumPoints  │ Little     │
+     * │ Byte Y*   │ Z|M min    │ Z|M min   │ Double  │ 1          │ Little     │
+     * │ Byte Y+8* │ Z|M max    │ Z|M max   │ Double  │ 1          │ Little     │
+     * │ Byte Y+16*│ Z|M Array  │ Z|M Array │ Double  │ NumPoints  │ Little     │
+     * │ Byte Z*   │ M min      │ M min     │ Double  │ 1          │ Little     │
+     * │ Byte Z+8* │ M max      │ M max     │ Double  │ 1          │ Little     │
+     * │ Byte Z+16*│ M Array    │ M Array   │ Double  │ NumPoints  │ Little     │
+     * └───────────┴────────────┴───────────┴─────────┴────────────┴────────────┘
+     *
+     * Notes:
+     *   X = 44 + (4  * NumParts)
+     *   Y = X  + (16 * NumPoints)
+     *   Z = Y  + 16 + (8 * NumPoints)
+     *
+     *   (*) optional.
+     */
+
+    private readonly ref struct PolygonOffsets : IBoundingBoxOffsets<PolygonOffsets>, IPartArrayOffsets<PolygonOffsets>
+    {
+        public int ShapeType { get; }
+        public int MinX { get; }
+        public int MinY { get; }
+        public int MaxX { get; }
+        public int MaxY { get; }
+        public int NumParts { get; }
+        public int NumPoints { get; }
+        public int Parts { get; }
+        public int Points { get; }
+        public int MinZ { get; }
+        public int MaxZ { get; }
+        public int ZArray { get; }
+        public int MinM { get; }
+        public int MaxM { get; }
+        public int MArray { get; }
+
+        private PolygonOffsets(ShapeType shapeType, int numParts, int numPoints)
+        {
+            ShapeType = 0;
+            if (shapeType is Shape.ShapeType.Null) return;
+
+            var x = 44 + 4 * numParts;
+            MinX = 4;
+            MinY = 12;
+            MaxX = 20;
+            MaxY = 28;
+            NumParts = 36;
+            NumPoints = 40;
+            Parts = 44;
+            Points = x;
+            if (shapeType is Shape.ShapeType.Polygon) return;
+
+            var y = x + 16 * numPoints;
+            var z = y + 16 + 8 * numPoints;
+            MinZ = y;
+            MaxZ = y + 8;
+            ZArray = y + 16;
+            if (shapeType is Shape.ShapeType.PolygonM) z = y;
+
+            MinM = z;
+            MaxM = z + 8;
+            MArray = z + 16;
+        }
+
+        public PolygonOffsets(Polygon polygon) : this(
+            shapeType: polygon.ShapeType,
+            numParts: polygon.Rings.Length,
+            numPoints: polygon.Rings.Sum(ls => ls.Length))
+        { }
+
+        public static PolygonOffsets Detect(ReadOnlySpan<byte> source)
+        {
+            var shapeType = (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source);
+            if (shapeType is Shape.ShapeType.Null)
+            {
+                return new PolygonOffsets(shapeType, 0, 0);
+            }
+
+            shapeType.EnsureCompatibleWith<Polygon>();
+
+            var numParts = BinaryPrimitives.ReadInt32LittleEndian(source[36..]);
+            var numPoints = BinaryPrimitives.ReadInt32LittleEndian(source[40..]);
+            return new PolygonOffsets(shapeType, numParts, numPoints);
+        }
+    }
+
+    public static int GetByteSize(Polygon geometry)
+    {
+        if (geometry.ShapeType is ShapeType.Null) return 4 /* ShapeType */;
+
+        var dimension = geometry.ShapeType.Dimension;
+        return
+            4 /* ShapeType */ +
+            dimension.BoundingBoxSize +
+            4 /* NumParts */ +
+            4 /* NumPoints */ +
+            geometry.Rings.Length * 4 /* Parts */ +
+            geometry.Rings.Sum(x => x.Length) * dimension.PointByteSize /* Points */;
+    }
+
+    public static void Serialize(Span<byte> target, Polygon polygon)
+    {
+        var offsets = new PolygonOffsets(polygon);
+        ShapeTypeSerializer.Serialize(target, offsets, polygon);
+        if (polygon.ShapeType is ShapeType.Null) return;
+        BoundingBoxSerializer.Serialize(target, offsets, polygon);
+        PartArraySerializer.Serialize(target, offsets, polygon.ShapeType, polygon.Rings);
+    }
+
+    public static Polygon Deserialize(ReadOnlySpan<byte> source)
+    {
+        var offsets = PolygonOffsets.Detect(source);
+        var shapeType = ShapeTypeSerializer.Deserialize(source, offsets);
+        if (shapeType is ShapeType.Null) return Polygon.Empty;
+        var rings = PartArraySerializer.Deserialize(source, offsets, (_, points) => new LinearRing(points));
+        return new Polygon(rings);
+    }
+}

--- a/src/Shape/Serialization/ShapeTypeSerializer.cs
+++ b/src/Shape/Serialization/ShapeTypeSerializer.cs
@@ -1,0 +1,20 @@
+﻿using System.Buffers.Binary;
+using Shape.Geometries;
+
+namespace Shape.Serialization;
+
+internal interface IShapeTypeOffsets<T> where T : allows ref struct
+{
+    public int ShapeType { get; }
+}
+
+internal static class ShapeTypeSerializer
+{
+    public static void Serialize<TOffsets>(Span<byte> target, TOffsets offsets, Geometry geometry)
+        where TOffsets : IShapeTypeOffsets<TOffsets>, allows ref struct =>
+        BinaryPrimitives.WriteInt32LittleEndian(target[offsets.ShapeType..], (int)geometry.ShapeType);
+
+    public static ShapeType Deserialize<TOffsets>(ReadOnlySpan<byte> source, TOffsets offsets)
+        where TOffsets : IShapeTypeOffsets<TOffsets>, allows ref struct =>
+        (ShapeType)BinaryPrimitives.ReadInt32LittleEndian(source[offsets.ShapeType..]);
+}

--- a/src/Shape/Shape.csproj
+++ b/src/Shape/Shape.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="DBase" />
   </ItemGroup>

--- a/src/Shape/ShapeIndex.cs
+++ b/src/Shape/ShapeIndex.cs
@@ -1,8 +1,9 @@
-﻿
-using System.Buffers.Binary;
+﻿using System.Buffers.Binary;
+using System.Collections;
 
 namespace Shape;
-public sealed class ShapeIndex : IDisposable
+
+public sealed class ShapeIndex : IDisposable, IEnumerable<ShapeIndexRecord>
 {
     internal const int HeaderLength = 100;
 
@@ -53,6 +54,7 @@ public sealed class ShapeIndex : IDisposable
             _shx.Position = 24;
             _shx.Write(hLength);
         }
+
         _shx.Flush();
     }
 
@@ -86,7 +88,7 @@ public sealed class ShapeIndex : IDisposable
         _shx.Write(buffer);
     }
 
-    public IEnumerable<ShapeIndexRecord> EnumerateRecords()
+    public IEnumerator<ShapeIndexRecord> GetEnumerator()
     {
         var count = RecordCount;
         for (var i = 0; i < count; i++)
@@ -94,4 +96,6 @@ public sealed class ShapeIndex : IDisposable
             yield return GetRecord(i);
         }
     }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Shape/ShapeRecord.cs
+++ b/src/Shape/ShapeRecord.cs
@@ -1,0 +1,9 @@
+﻿using Shape.Geometries;
+
+namespace Shape;
+
+public readonly record struct ShapeRecord<TGeometry, TAttributes>(TGeometry Geometry, TAttributes Attributes)
+    where TGeometry : Geometry
+{
+    public static ShapeRecord<TGeometry, TAttributes> Create(TGeometry geometry, TAttributes attributes) => new(geometry, attributes);
+}

--- a/src/Shape/ShapeTypeExtensions.cs
+++ b/src/Shape/ShapeTypeExtensions.cs
@@ -4,34 +4,43 @@ namespace Shape;
 
 internal static class ShapeTypeExtensions
 {
-    public static bool HasZ(this ShapeType shapeType) => shapeType switch
+    extension(ShapeType shapeType)
     {
-        ShapeType.PointZ => true,
-        ShapeType.PolyLineZ => true,
-        ShapeType.PolygonZ => true,
-        ShapeType.MultiPointZ => true,
-        _ => false
-    };
+        public bool HasZ => (int)shapeType / 10 is 1 or 3;
 
-    public static bool HasM(this ShapeType shapeType) => shapeType switch
-    {
-        ShapeType.PointM => true,
-        ShapeType.PolyLineM => true,
-        ShapeType.PolygonM => true,
-        ShapeType.MultiPointM => true,
-        _ => false
-    };
+        public bool HasM => (int)shapeType / 10 >= 1;
 
-    public static bool IsCompatibleWithGeometry<T>(this ShapeType shapeType) =>
-        shapeType.IsCompatibleWithGeometry(typeof(T));
+        public Dimension Dimension => ((int)shapeType / 10) switch
+        {
+            3 => Dimension.Xyzm,
+            2 => Dimension.Xym,
+            1 => Dimension.Xyzm,
+            0 when shapeType is not ShapeType.Null => Dimension.Xy,
+            _ => Dimension.None,
+        };
 
-    public static bool IsCompatibleWithGeometry(this ShapeType shapeType, Type geometryType) => shapeType switch
-    {
-        ShapeType.Point or ShapeType.PointZ or ShapeType.PointM => geometryType == typeof(Point),
-        ShapeType.PolyLine or ShapeType.PolyLineZ or ShapeType.PolyLineM => geometryType == typeof(PolyLine),
-        ShapeType.Polygon or ShapeType.PolygonZ or ShapeType.PolygonM => geometryType == typeof(Polygon),
-        ShapeType.MultiPoint or ShapeType.MultiPointZ or ShapeType.MultiPointM => geometryType == typeof(MultiPoint),
-        ShapeType.MultiPatch => geometryType == typeof(MultiPatch),
-        _ => false
-    };
+        public void EnsureCompatibleWith<T>() where T : Geometry
+        {
+            var geometryType = typeof(T);
+            if (geometryType == typeof(Geometry))
+            {
+                return;
+            }
+
+            var isCompatible = shapeType switch
+            {
+                ShapeType.Point or ShapeType.PointZ or ShapeType.PointM => geometryType == typeof(Point),
+                ShapeType.PolyLine or ShapeType.PolyLineZ or ShapeType.PolyLineM => geometryType == typeof(PolyLine),
+                ShapeType.Polygon or ShapeType.PolygonZ or ShapeType.PolygonM => geometryType == typeof(Polygon),
+                ShapeType.MultiPoint or ShapeType.MultiPointZ or ShapeType.MultiPointM => geometryType == typeof(MultiPoint),
+                ShapeType.MultiPatch => geometryType == typeof(MultiPatch),
+                _ => false
+            };
+
+            if (!isCompatible)
+            {
+                throw new InvalidOperationException($"{nameof(ShapeType)} '{shapeType}' is not compatible with {typeof(T)}");
+            }
+        }
+    }
 }

--- a/src/Shape/Shapefile.cs
+++ b/src/Shape/Shapefile.cs
@@ -1,77 +1,117 @@
 ﻿using System.Buffers.Binary;
+using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using DBase;
 using DotNext.Buffers;
 using Shape.Geometries;
+using Shape.Serialization;
 
 namespace Shape;
 
-public abstract class Shapefile<TGeometry, TAttributes>
-    where TGeometry : Geometry
+public sealed class Shapefile : Shapefile<Geometry, DbfRecord, GeometrySerializer>
 {
+    internal Shapefile(Stream shp, ShapeIndex shx, Dbf dbf, ShapeType shapeType, BoundingBox boundingBox)
+        : base(shp, shx, dbf, shapeType, boundingBox) { }
+
+    public static Shapefile Open(string fileName)
+    {
+        var (shp, shx, dbf, shapeType, boundingBox) = OpenCore(fileName);
+        return new Shapefile(shp, shx, dbf, shapeType, boundingBox);
+    }
+
+    public static Shapefile<TGeometry> Open<TGeometry>(string fileName)
+        where TGeometry : Geometry, IGeometrySerializer<TGeometry>
+    {
+        var (shp, shx, dbf, shapeType, boundingBox) = OpenCore(fileName);
+        return new Shapefile<TGeometry>(shp, shx, dbf, shapeType, boundingBox);
+    }
+
+    public static Shapefile<TGeometry, TAttributes> Open<TGeometry, TAttributes>(string fileName)
+        where TGeometry : Geometry, IGeometrySerializer<TGeometry>
+    {
+        var (shp, shx, dbf, shapeType, boundingBox) = OpenCore(fileName);
+        return new Shapefile<TGeometry, TAttributes>(shp, shx, dbf, shapeType, boundingBox);
+    }
+
+    private static (FileStream shp, ShapeIndex shx, Dbf dbf, ShapeType shapeType, BoundingBox boundingBox) OpenCore(string fileName)
+    {
+        var shp = new FileStream(fileName, FileMode.Open, FileAccess.ReadWrite);
+        var shx = ShapeIndex.Open(Path.ChangeExtension(fileName, ".shx"));
+        var dbf = Dbf.Open(Path.ChangeExtension(fileName, ".dbf"));
+
+        var (shapeType, boundingBox) = ReadHeader(shp);
+        return (shp, shx, dbf, shapeType, boundingBox);
+    }
+
+    //public Shapefile<TGeometry> As<TGeometry>() where TGeometry : Geometry, IGeometrySerializer<TGeometry>
+    //{
+    //    return new Shapefile<TGeometry>()
+    //}
+
+    //public Shapefile<TGeometry, TAttributes> As<TGeometry, TAttributes>() where TGeometry : Geometry, IGeometrySerializer<TGeometry>
+    //{
+    //    return new Shapefile<TGeometry, TAttributes>()
+    //}
 }
 
-public sealed class Shapefile : IDisposable
+public sealed class Shapefile<TGeometry> : Shapefile<TGeometry, DbfRecord, TGeometry>
+    where TGeometry : Geometry, IGeometrySerializer<TGeometry>
 {
+    internal Shapefile(Stream shp, ShapeIndex shx, Dbf dbf, ShapeType shapeType, BoundingBox boundingBox)
+        : base(shp, shx, dbf, shapeType, boundingBox) { }
+}
+
+public sealed class Shapefile<TGeometry, TAttributes> : Shapefile<TGeometry, TAttributes, TGeometry>
+    where TGeometry : Geometry, IGeometrySerializer<TGeometry>
+{
+    internal Shapefile(Stream shp, ShapeIndex shx, Dbf dbf, ShapeType shapeType, BoundingBox boundingBox)
+        : base(shp, shx, dbf, shapeType, boundingBox) { }
+}
+
+public abstract class Shapefile<TGeometry, TAttributes, TSerializer>
+    : IShapefile, IDisposable, IEnumerable<ShapeRecord<TGeometry, TAttributes>>
+    where TGeometry : Geometry
+    where TSerializer : IGeometrySerializer<TGeometry>
+{
+    private bool _dirty;
     private readonly Stream _shp;
     private readonly ShapeIndex _shx;
     private readonly Dbf _dbf;
-    private bool _dirty;
+
+    protected Shapefile(Stream shp, ShapeIndex shx, Dbf dbf, ShapeType shapeType, BoundingBox boundingBox)
+    {
+        _shp = shp;
+        _shx = shx;
+        _dbf = dbf;
+        ShapeType = shapeType;
+        BoundingBox = boundingBox;
+
+        ShapeType.EnsureCompatibleWith<TGeometry>();
+    }
 
     public ShapeType ShapeType { get; }
+
     public BoundingBox BoundingBox { get; }
 
     public int RecordCount => _shx.RecordCount;
 
-    private Shapefile(Stream shp, ShapeIndex shx, Dbf dbf, ShapeType shapeType, BoundingBox boundingBox)
+    internal int PrepareStreamToReadRecord(int index)
     {
-        _shp = shp;
-        _shx = shx;
-        ShapeType = shapeType;
-        BoundingBox = boundingBox;
-        _dbf = dbf;
+        var (offset, length) = _shx.GetRecord(index);
+#if !DEBUG
+        shp.Position = offset + 8;
+#else
+        _shp.Position = offset;
+        Span<byte> buffer = stackalloc byte[8];
+        _shp.ReadExactly(buffer);
+        Debug.Assert(BinaryPrimitives.ReadInt32BigEndian(buffer[0..]) == index + 1);
+        Debug.Assert(BinaryPrimitives.ReadInt32BigEndian(buffer[4..]) == length / 2);
+#endif
+        return length;
     }
 
-    public static Shapefile Open(string fileName)
-    {
-        return Open(
-            new FileStream(fileName, FileMode.Open, FileAccess.ReadWrite),
-            ShapeIndex.Open(Path.ChangeExtension(fileName, ".shx")),
-            Dbf.Open(Path.ChangeExtension(fileName, ".dbf")));
-    }
-
-    internal static Shapefile Open(Stream shp, ShapeIndex shx, Dbf dbf)
-    {
-        ArgumentNullException.ThrowIfNull(shp);
-        ArgumentNullException.ThrowIfNull(shx);
-        ArgumentNullException.ThrowIfNull(dbf);
-
-        var (shapeType, boundingBox) = ReadHeader(shp);
-        return new Shapefile(shp, shx, dbf, shapeType, boundingBox);
-    }
-
-    public void Dispose()
-    {
-        Flush();
-        _dbf.Dispose();
-        _shp.Dispose();
-        _shx.Dispose();
-    }
-
-    public void Flush()
-    {
-        if (_dirty)
-        {
-            _dirty = false;
-            WriteHeader(_shp, ShapeType, BoundingBox);
-        }
-        _dbf.Flush();
-        _shp.Flush();
-        _shx.Flush();
-    }
-
-    private static (ShapeType ShapeType, BoundingBox BoundingBox) ReadHeader(Stream stream)
+    protected static (ShapeType ShapeType, BoundingBox BoundingBox) ReadHeader(Stream stream)
     {
         stream.Position = 0;
         Span<byte> buffer = stackalloc byte[100];
@@ -98,11 +138,11 @@ public sealed class Shapefile : IDisposable
         var mMax = BinaryPrimitives.ReadDoubleLittleEndian(buffer[92..]);
 
         Unsafe.SkipInit(out BoundingBox boundingBox);
-        if (shapeType.HasZ())
+        if (shapeType.HasZ)
         {
             boundingBox = new BoundingBox(new Point(xMin, yMin, zMin, mMin), new Point(xMax, yMax, zMax, mMax));
         }
-        else if (shapeType.HasM())
+        else if (shapeType.HasM)
         {
             boundingBox = new BoundingBox(new Point(xMin, yMin, mMin), new Point(xMax, yMax, mMax));
         }
@@ -114,7 +154,7 @@ public sealed class Shapefile : IDisposable
         return (shapeType, boundingBox);
     }
 
-    private static void WriteHeader(Stream stream, ShapeType shapeType, BoundingBox boundingBox)
+    protected static void WriteHeader(Stream stream, ShapeType shapeType, BoundingBox boundingBox)
     {
         stream.Position = 0;
         Span<byte> buffer = stackalloc byte[100];
@@ -126,30 +166,13 @@ public sealed class Shapefile : IDisposable
         BinaryPrimitives.WriteDoubleLittleEndian(buffer[44..], boundingBox.MinY);
         BinaryPrimitives.WriteDoubleLittleEndian(buffer[52..], boundingBox.MaxX);
         BinaryPrimitives.WriteDoubleLittleEndian(buffer[60..], boundingBox.MaxY);
-        BinaryPrimitives.WriteDoubleLittleEndian(buffer[68..], shapeType.HasZ() ? boundingBox.MinZ : 0.0);
-        BinaryPrimitives.WriteDoubleLittleEndian(buffer[76..], shapeType.HasZ() ? boundingBox.MaxZ : 0.0);
-        BinaryPrimitives.WriteDoubleLittleEndian(buffer[84..], shapeType.HasM() ? boundingBox.MinM : 0.0);
-        BinaryPrimitives.WriteDoubleLittleEndian(buffer[92..], shapeType.HasM() ? boundingBox.MaxM : 0.0);
+        BinaryPrimitives.WriteDoubleLittleEndian(buffer[68..], shapeType.HasZ ? boundingBox.MinZ : 0.0);
+        BinaryPrimitives.WriteDoubleLittleEndian(buffer[76..], shapeType.HasZ ? boundingBox.MaxZ : 0.0);
+        BinaryPrimitives.WriteDoubleLittleEndian(buffer[84..], shapeType.HasM ? boundingBox.MinM : 0.0);
+        BinaryPrimitives.WriteDoubleLittleEndian(buffer[92..], shapeType.HasM ? boundingBox.MaxM : 0.0);
     }
 
-
-    internal int PrepareStreamToReadRecord(int index)
-    {
-        var (offset, length) = _shx.GetRecord(index);
-#if !DEBUG
-        _shp.Position = offset + 8;
-#else
-        _shp.Position = offset;
-        Span<byte> buffer = stackalloc byte[8];
-        _shp.ReadExactly(buffer);
-        Debug.Assert(BinaryPrimitives.ReadInt32BigEndian(buffer[0..]) == index + 1);
-        Debug.Assert(BinaryPrimitives.ReadInt32BigEndian(buffer[4..]) == length / 2);
-#endif
-        return length;
-    }
-
-
-    public ShapeRecord<Geometry, DbfRecord> GetRecord(int index)
+    public ShapeRecord<TGeometry, TAttributes> GetRecord(int index)
     {
         var length = PrepareStreamToReadRecord(index);
 
@@ -159,81 +182,72 @@ public sealed class Shapefile : IDisposable
 
         _shp.ReadExactly(buffer.Span);
 
-        var geometry = Geometry.Read(buffer.Span, ShapeType);
+        var geometry = TSerializer.Deserialize(buffer.Span);
+        var attributes = _dbf.GetRecord<TAttributes>(index);
+        return ShapeRecord<TGeometry, TAttributes>.Create(geometry, attributes);
+    }
+
+    // TODO: We can probably unify this with the method above by moving the read into another class.
+    ShapeRecord<Geometry, DbfRecord> IShapefile.GetRecord(int index)
+    {
+        var length = PrepareStreamToReadRecord(index);
+
+        using var buffer = length < 256
+            ? new SpanOwner<byte>(stackalloc byte[length])
+            : new SpanOwner<byte>(length);
+
+        _shp.ReadExactly(buffer.Span);
+
+        var geometry = GeometrySerializer.Deserialize(buffer.Span);
         var attributes = _dbf.GetRecord(index);
         return new ShapeRecord<Geometry, DbfRecord>(geometry, attributes);
     }
 
-    public ShapeRecord<TGeometry, DbfRecord> GetRecord<TGeometry>(int index)
-        where TGeometry : Geometry, IGeometry<TGeometry>
-    {
-        if (!ShapeType.IsCompatibleWithGeometry<TGeometry>())
-        {
-            throw new InvalidOperationException($"Shape type '{ShapeType}' is not compatible with geometry type '{typeof(TGeometry)}'");
-        }
-
-        var length = PrepareStreamToReadRecord(index);
-
-        using var buffer = length < 256
-            ? new SpanOwner<byte>(stackalloc byte[length])
-            : new SpanOwner<byte>(length);
-
-        _shp.ReadExactly(buffer.Span);
-
-        var geometry = TGeometry.Read(buffer.Span);
-        var attributes = _dbf.GetRecord(index);
-        return new ShapeRecord<TGeometry, DbfRecord>(geometry, attributes);
-    }
-
-    public ShapeRecord<TGeometry, TAttributes> GetRecord<TGeometry, TAttributes>(int index)
-        where TGeometry : Geometry, IGeometry<TGeometry>
-    {
-        if (!ShapeType.IsCompatibleWithGeometry<TGeometry>())
-        {
-            throw new InvalidOperationException($"Shape type '{ShapeType}' is not compatible with geometry type '{typeof(TGeometry)}'");
-        }
-
-        var length = PrepareStreamToReadRecord(index);
-
-        using var buffer = length < 256
-            ? new SpanOwner<byte>(stackalloc byte[length])
-            : new SpanOwner<byte>(length);
-
-        _shp.ReadExactly(buffer.Span);
-
-        var geometry = TGeometry.Read(buffer.Span);
-        var attributes = _dbf.GetRecord<TAttributes>(index);
-        return new ShapeRecord<TGeometry, TAttributes>(geometry, attributes);
-    }
-
-    public IEnumerable<ShapeRecord<Geometry, DbfRecord>> EnumerateRecords()
+    public IEnumerator<ShapeRecord<TGeometry, TAttributes>> GetEnumerator()
     {
         var recordCount = RecordCount;
         for (var i = 0; i < recordCount; ++i)
             yield return GetRecord(i);
     }
 
-    public IEnumerable<ShapeRecord<TGeometry, DbfRecord>> EnumerateRecords<TGeometry>()
-        where TGeometry : Geometry, IGeometry<TGeometry>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public void Add(ShapeRecord<TGeometry, TAttributes> record) => Add(record.Geometry, record.Attributes);
+
+    public void Add(TGeometry geometry, TAttributes attributes)
     {
-        var recordCount = RecordCount;
-        for (var i = 0; i < recordCount; ++i)
-            yield return GetRecord<TGeometry>(i);
+        _dirty = true;
+        var index = new ShapeIndexRecord((int)_shp.Length, TSerializer.GetByteSize(geometry));
+
+        using var buffer = index.Length < 256
+            ? new SpanOwner<byte>(stackalloc byte[index.Length])
+            : new SpanOwner<byte>(index.Length);
+
+        TSerializer.Serialize(buffer.Span, geometry);
+
+        _shx.Add(index);
+        _dbf.Add(attributes);
+        _shp.Write(buffer.Span);
     }
 
-    public IEnumerable<ShapeRecord<TGeometry, TAttributes>> EnumerateRecords<TGeometry, TAttributes>()
-        where TGeometry : Geometry, IGeometry<TGeometry>
+    public void Dispose()
     {
-        var recordCount = RecordCount;
-        for (var i = 0; i < recordCount; ++i)
-            yield return GetRecord<TGeometry, TAttributes>(i);
+        Flush();
+        _dbf.Dispose();
+        _shp.Dispose();
+        _shx.Dispose();
+    }
+
+    public void Flush()
+    {
+        if (_dirty)
+        {
+            _dirty = false;
+            WriteHeader(_shp, ShapeType, BoundingBox);
+        }
+
+        _dbf.Flush();
+        _shp.Flush();
+        _shx.Flush();
     }
 }
-
-public sealed record class ShapeRecord<TGeometry, TAttributes>(TGeometry Geometry, TAttributes Attributes)
-    where TGeometry : Geometry;
-
-public sealed record class ShapeRecord<TGeometry>(TGeometry Geometry, DbfRecord Attributes)
-    where TGeometry : Geometry;
-
-public sealed record class ShapeRecord(Geometry Geometry, DbfRecord Attributes);

--- a/tests/Shape.Tests/Serialization/MultiPatchSerializerTests.cs
+++ b/tests/Shape.Tests/Serialization/MultiPatchSerializerTests.cs
@@ -1,0 +1,335 @@
+﻿using System.Collections.Immutable;
+using Shape.Geometries;
+using Shape.Serialization;
+
+namespace Shape.Tests.Serialization;
+
+public sealed class MultiPatchSerializerTests : SerializerTests
+{
+    // Test geometry:
+    // - Surface 0: TriangleStrip (0), 4 points
+    // - Surface 1: FirstRing (4), 5 points (closed)
+    //
+    // NumParts = 2
+    // NumPoints = 9
+    // Parts = [0, 4]
+    // PartTypes = [0, 4]
+
+    [Fact]
+    public void Deserialize_Null_ReturnsEmpty()
+    {
+        var buf = new byte[4];
+        WriteI32(buf, 0, (int)ShapeType.Null);
+
+        var mp = MultiPatchSerializer.Deserialize(buf);
+
+        Assert.Equal(MultiPatch.Empty, mp);
+    }
+
+    [Fact]
+    public void Deserialize_MultiPatch_AllMNoValue_ReadsSurfacesPointsZArrayAndMArray_PerSpec()
+    {
+        // MultiPatch record contents always include M range + M array (values may be NoData).
+        // Size for this geometry:
+        // 4 + 32 + 4 + 4 + (2*4) + (2*4) + (9*16) + 16 + (9*8) + 16 + (9*8) = 380
+        var buf = new byte[380];
+
+        WriteMultiPatchHeader(
+            buf,
+            shapeType: ShapeType.MultiPatch,
+            xmin: 0,
+            ymin: 0,
+            xmax: 10,
+            ymax: 10,
+            numParts: 2,
+            numPoints: 9);
+
+        // Parts @ 44
+        WriteI32(buf, 44, 0);
+        WriteI32(buf, 48, 4);
+
+        // PartTypes @ 52
+        WriteI32(buf, 52, 0); // TriangleStrip
+        WriteI32(buf, 56, 4); // FirstRing
+
+        // Points @ 60 (XY)
+        var pointsOffset = 60;
+
+        // Surface0 strip (4 points)
+        WriteXY(buf, pointsOffset, 0, 0, 0);
+        WriteXY(buf, pointsOffset, 1, 1, 0);
+        WriteXY(buf, pointsOffset, 2, 1, 1);
+        WriteXY(buf, pointsOffset, 3, 0, 1);
+
+        // Surface1 ring (5 points, closed)
+        WriteXY(buf, pointsOffset, 4, 0, 0);
+        WriteXY(buf, pointsOffset, 5, 10, 0);
+        WriteXY(buf, pointsOffset, 6, 10, 10);
+        WriteXY(buf, pointsOffset, 7, 0, 10);
+        WriteXY(buf, pointsOffset, 8, 0, 0);
+
+        // Z section begins at:
+        // Y = X + 16*NumPoints = 60 + 16*9 = 204
+        var zSection = 204;
+
+        // Zmin/Zmax
+        WriteF64(buf, zSection + 0, 1000);
+        WriteF64(buf, zSection + 8, 1008);
+
+        // Z array at zSection+16
+        var zArray = zSection + 16;
+        for (var i = 0; i < 9; i++)
+            WriteF64(buf, zArray + i * 8, 1000 + i);
+
+        // M section begins at:
+        // Z = Y + 16 + 8*NumPoints = 204 + 16 + 72 = 292
+        var mSection = 292;
+
+        // Spec: M section exists; NoData is encoded by any value < -1e38.
+        // We'll write your library's NoValue constant.
+        WriteF64(buf, mSection + 0, NumericLimits.NoValue); // Mmin
+        WriteF64(buf, mSection + 8, NumericLimits.NoValue); // Mmax
+
+        var mArray = mSection + 16;
+        for (var i = 0; i < 9; i++)
+            WriteF64(buf, mArray + i * 8, NumericLimits.NoValue);
+
+        var mp = MultiPatchSerializer.Deserialize(buf);
+
+        Assert.Equal(2, mp.Surfaces.Length);
+
+        Assert.Equal((SurfaceType)0, mp.Surfaces[0].Type);
+        Assert.Equal(4, mp.Surfaces[0].Points.Length);
+        AssertPoint(mp.Surfaces[0].Points[0], 0, 0, 1000, NumericLimits.NoValue);
+        AssertPoint(mp.Surfaces[0].Points[3], 0, 1, 1003, NumericLimits.NoValue);
+
+        Assert.Equal((SurfaceType)4, mp.Surfaces[1].Type);
+        Assert.Equal(5, mp.Surfaces[1].Points.Length);
+        AssertPoint(mp.Surfaces[1].Points[0], 0, 0, 1004, NumericLimits.NoValue);
+        AssertPoint(mp.Surfaces[1].Points[4], 0, 0, 1008, NumericLimits.NoValue);
+    }
+
+    [Fact]
+    public void Deserialize_MultiPatch_WithM_ReadsMRangeAndMArray_PerSpec()
+    {
+        // MultiPatch record contents include M range + M array.
+        // Size = 380 for this geometry.
+        var buf = new byte[380];
+
+        WriteMultiPatchHeader(
+            buf,
+            shapeType: ShapeType.MultiPatch,
+            xmin: 0,
+            ymin: 0,
+            xmax: 10,
+            ymax: 10,
+            numParts: 2,
+            numPoints: 9);
+
+        // Parts
+        WriteI32(buf, 44, 0);
+        WriteI32(buf, 48, 4);
+
+        // PartTypes
+        WriteI32(buf, 52, 0);
+        WriteI32(buf, 56, 4);
+
+        // XY points
+        var pointsOffset = 60;
+
+        WriteXY(buf, pointsOffset, 0, 0, 0);
+        WriteXY(buf, pointsOffset, 1, 1, 0);
+        WriteXY(buf, pointsOffset, 2, 1, 1);
+        WriteXY(buf, pointsOffset, 3, 0, 1);
+
+        WriteXY(buf, pointsOffset, 4, 0, 0);
+        WriteXY(buf, pointsOffset, 5, 10, 0);
+        WriteXY(buf, pointsOffset, 6, 10, 10);
+        WriteXY(buf, pointsOffset, 7, 0, 10);
+        WriteXY(buf, pointsOffset, 8, 0, 0);
+
+        // Z section at 204
+        var zSection = 204;
+        WriteF64(buf, zSection + 0, 1000);
+        WriteF64(buf, zSection + 8, 1008);
+
+        var zArray = zSection + 16;
+        for (var i = 0; i < 9; i++)
+            WriteF64(buf, zArray + i * 8, 1000 + i);
+
+        // M section begins at 292
+        var mSection = 292;
+
+        WriteF64(buf, mSection + 0, 2000); // Mmin
+        WriteF64(buf, mSection + 8, 2008); // Mmax
+
+        var mArray = mSection + 16;
+        for (var i = 0; i < 9; i++)
+            WriteF64(buf, mArray + i * 8, 2000 + i);
+
+        var mp = MultiPatchSerializer.Deserialize(buf);
+
+        Assert.Equal(2, mp.Surfaces.Length);
+
+        AssertPoint(mp.Surfaces[0].Points[0], 0, 0, 1000, 2000);
+        AssertPoint(mp.Surfaces[0].Points[3], 0, 1, 1003, 2003);
+
+        AssertPoint(mp.Surfaces[1].Points[0], 0, 0, 1004, 2004);
+        AssertPoint(mp.Surfaces[1].Points[4], 0, 0, 1008, 2008);
+    }
+
+    // --- Serialize layout tests (will fail until MultiPatchSerializer.Serialize is implemented) ---
+
+    [Fact]
+    public void Serialize_MultiPatch_AllMNoValue_WritesSpecLayout_ThroughMArray()
+    {
+        // MultiPatch must write an M section; "no M" means values are NoValue.
+        var mp = MakeMultiPatch_AllMNoValue();
+        var buf = new byte[380];
+
+        MultiPatchSerializer.Serialize(buf, mp);
+
+        Assert.Equal((int)ShapeType.MultiPatch, ReadI32(buf, 0));
+        Assert.Equal(2, ReadI32(buf, 36)); // NumParts
+        Assert.Equal(9, ReadI32(buf, 40)); // NumPoints
+
+        // Parts
+        Assert.Equal(0, ReadI32(buf, 44));
+        Assert.Equal(4, ReadI32(buf, 48));
+
+        // PartTypes @ 52
+        Assert.Equal(0, ReadI32(buf, 52));
+        Assert.Equal(4, ReadI32(buf, 56));
+
+        // Points start @ 60
+        var pointsOffset = 60;
+        AssertXY(buf, pointsOffset, 0, 0, 0);
+        AssertXY(buf, pointsOffset, 8, 0, 0);
+
+        // Z section @ 204
+        var zSection = 204;
+        Assert.Equal(1000, ReadF64(buf, zSection + 0)); // Zmin
+        Assert.Equal(1008, ReadF64(buf, zSection + 8)); // Zmax
+
+        var zArray = zSection + 16;
+        Assert.Equal(1000, ReadF64(buf, zArray + 0 * 8));
+        Assert.Equal(1008, ReadF64(buf, zArray + 8 * 8));
+
+        // M section @ 292
+        var mSection = 292;
+
+        Assert.Equal(NumericLimits.NoValue, ReadF64(buf, mSection + 0)); // Mmin
+        Assert.Equal(NumericLimits.NoValue, ReadF64(buf, mSection + 8)); // Mmax
+
+        var mArray = mSection + 16;
+        Assert.Equal(NumericLimits.NoValue, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(NumericLimits.NoValue, ReadF64(buf, mArray + 8 * 8));
+    }
+
+    [Fact]
+    public void Serialize_MultiPatch_WithM_WritesMRangeAndMArray()
+    {
+        var mp = MakeMultiPatch_WithM();
+        var buf = new byte[380];
+
+        MultiPatchSerializer.Serialize(buf, mp);
+
+        Assert.Equal((int)ShapeType.MultiPatch, ReadI32(buf, 0));
+        Assert.Equal(2, ReadI32(buf, 36));
+        Assert.Equal(9, ReadI32(buf, 40));
+
+        // M section begins @ 292 for this geometry
+        var mSection = 292;
+        Assert.Equal(2000, ReadF64(buf, mSection + 0)); // Mmin
+        Assert.Equal(2008, ReadF64(buf, mSection + 8)); // Mmax
+
+        var mArray = mSection + 16;
+        Assert.Equal(2000, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(2008, ReadF64(buf, mArray + 8 * 8));
+    }
+
+    // ---- local helpers ----
+
+    private static void WriteMultiPatchHeader(
+        byte[] buf,
+        ShapeType shapeType,
+        double xmin,
+        double ymin,
+        double xmax,
+        double ymax,
+        int numParts,
+        int numPoints)
+    {
+        WriteI32(buf, 0, (int)shapeType);
+        WriteF64(buf, 4, xmin);
+        WriteF64(buf, 12, ymin);
+        WriteF64(buf, 20, xmax);
+        WriteF64(buf, 28, ymax);
+        WriteI32(buf, 36, numParts);
+        WriteI32(buf, 40, numPoints);
+    }
+
+    private static void WriteXY(byte[] buf, int pointsOffset, int index, double x, double y)
+    {
+        WriteF64(buf, pointsOffset + index * 16 + 0, x);
+        WriteF64(buf, pointsOffset + index * 16 + 8, y);
+    }
+
+    private static void AssertXY(byte[] buf, int pointsOffset, int index, double x, double y)
+    {
+        Assert.Equal(x, ReadF64(buf, pointsOffset + index * 16 + 0));
+        Assert.Equal(y, ReadF64(buf, pointsOffset + index * 16 + 8));
+    }
+
+    private static void AssertPoint(Point p, double x, double y, double z, double m)
+    {
+        Assert.Equal(x, p.X);
+        Assert.Equal(y, p.Y);
+        Assert.Equal(z, p.Z);
+        Assert.Equal(m, p.M);
+    }
+
+    private static MultiPatch MakeMultiPatch_AllMNoValue()
+    {
+        var s0 = new Surface(
+            (SurfaceType)0,
+            ImmutableArray.Create(
+                new Point(0, 0, 1000, NumericLimits.NoValue),
+                new Point(1, 0, 1001, NumericLimits.NoValue),
+                new Point(1, 1, 1002, NumericLimits.NoValue),
+                new Point(0, 1, 1003, NumericLimits.NoValue)));
+
+        var s1 = new Surface(
+            (SurfaceType)4,
+            ImmutableArray.Create(
+                new Point(0, 0, 1004, NumericLimits.NoValue),
+                new Point(10, 0, 1005, NumericLimits.NoValue),
+                new Point(10, 10, 1006, NumericLimits.NoValue),
+                new Point(0, 10, 1007, NumericLimits.NoValue),
+                new Point(0, 0, 1008, NumericLimits.NoValue)));
+
+        return new MultiPatch(ImmutableArray.Create(s0, s1));
+    }
+
+    private static MultiPatch MakeMultiPatch_WithM()
+    {
+        var s0 = new Surface(
+            (SurfaceType)0,
+            ImmutableArray.Create(
+                new Point(0, 0, 1000, 2000),
+                new Point(1, 0, 1001, 2001),
+                new Point(1, 1, 1002, 2002),
+                new Point(0, 1, 1003, 2003)));
+
+        var s1 = new Surface(
+            (SurfaceType)4,
+            ImmutableArray.Create(
+                new Point(0, 0, 1004, 2004),
+                new Point(10, 0, 1005, 2005),
+                new Point(10, 10, 1006, 2006),
+                new Point(0, 10, 1007, 2007),
+                new Point(0, 0, 1008, 2008)));
+
+        return new MultiPatch(ImmutableArray.Create(s0, s1));
+    }
+}

--- a/tests/Shape.Tests/Serialization/MultiPointSerializerTests .cs
+++ b/tests/Shape.Tests/Serialization/MultiPointSerializerTests .cs
@@ -1,0 +1,276 @@
+﻿using System.Collections.Immutable;
+using Shape.Geometries;
+using Shape.Serialization;
+
+namespace Shape.Tests.Serialization;
+
+public sealed class MultiPointSerializerTests : SerializerTests
+{
+    [Fact]
+    public void Deserialize_Null_ReturnsEmpty()
+    {
+        var buf = new byte[4];
+        WriteI32(buf, 0, (int)ShapeType.Null);
+
+        var mp = MultiPointSerializer.Deserialize(buf);
+
+        Assert.Equal(MultiPoint.Empty, mp);
+    }
+
+    [Fact]
+    public void Deserialize_MultiPoint_ReadsBoxCountAndXYPoints_PerSpec()
+    {
+        // 3 points: (0,0), (10,10), (-5,2)
+        // Box: Xmin=-5, Ymin=0, Xmax=10, Ymax=10
+        //
+        // Size = 4 (type) + 32 (box) + 4 (numPoints) + 3*16 (XY) = 88
+        var buf = new byte[88];
+
+        WriteI32(buf, 0, (int)ShapeType.MultiPoint);
+
+        // Box
+        WriteF64(buf, 4, -5); // Xmin
+        WriteF64(buf, 12, 0); // Ymin
+        WriteF64(buf, 20, 10); // Xmax
+        WriteF64(buf, 28, 10); // Ymax
+
+        WriteI32(buf, 36, 3); // NumPoints
+
+        var pointsOffset = 40;
+
+        WriteXY(0, 0, 0);
+        WriteXY(1, 10, 10);
+        WriteXY(2, -5, 2);
+
+        var mp = MultiPointSerializer.Deserialize(buf);
+
+        Assert.Equal(3, mp.Points.Length);
+        AssertPoint(mp.Points[0], 0, 0, NumericLimits.NoValue, NumericLimits.NoValue);
+        AssertPoint(mp.Points[1], 10, 10, NumericLimits.NoValue, NumericLimits.NoValue);
+        AssertPoint(mp.Points[2], -5, 2, NumericLimits.NoValue, NumericLimits.NoValue);
+
+        void WriteXY(int index, double x, double y)
+        {
+            WriteF64(buf, pointsOffset + index * 16 + 0, x);
+            WriteF64(buf, pointsOffset + index * 16 + 8, y);
+        }
+    }
+
+    [Fact]
+    public void Deserialize_MultiPointM_ReadsMSectionAfterXY_PerSpec()
+    {
+        // Same 3 points, plus Mmin/Mmax and Marray[3]
+        // Size = MultiPoint(88) + 16 + 3*8(=24) = 128
+        var buf = new byte[128];
+
+        WriteI32(buf, 0, (int)ShapeType.MultiPointM);
+
+        // Box
+        WriteF64(buf, 4, -5);
+        WriteF64(buf, 12, 0);
+        WriteF64(buf, 20, 10);
+        WriteF64(buf, 28, 10);
+
+        WriteI32(buf, 36, 3); // NumPoints
+
+        var pointsOffset = 40;
+        WriteXY(0, 0, 0);
+        WriteXY(1, 10, 10);
+        WriteXY(2, -5, 2);
+
+        // M section begins after XY points
+        var mSection = pointsOffset + 3 * 16;
+        WriteF64(buf, mSection + 0, 100); // Mmin
+        WriteF64(buf, mSection + 8, 102); // Mmax
+
+        var mArray = mSection + 16;
+        WriteF64(buf, mArray + 0 * 8, 100);
+        WriteF64(buf, mArray + 1 * 8, 101);
+        WriteF64(buf, mArray + 2 * 8, 102);
+
+        var mp = MultiPointSerializer.Deserialize(buf);
+
+        Assert.Equal(3, mp.Points.Length);
+        AssertPoint(mp.Points[0], 0, 0, NumericLimits.NoValue, 100);
+        AssertPoint(mp.Points[1], 10, 10, NumericLimits.NoValue, 101);
+        AssertPoint(mp.Points[2], -5, 2, NumericLimits.NoValue, 102);
+
+        void WriteXY(int index, double x, double y)
+        {
+            WriteF64(buf, pointsOffset + index * 16 + 0, x);
+            WriteF64(buf, pointsOffset + index * 16 + 8, y);
+        }
+    }
+
+    [Fact]
+    public void Deserialize_MultiPointZ_ReadsZThenMSections_PerSpec()
+    {
+        // Same 3 points, plus Z and M sections
+        // Size = MultiPoint(88) + (16 + 3*8=24) + (16 + 24) = 88 + 40 + 40 = 168
+        var buf = new byte[168];
+
+        WriteI32(buf, 0, (int)ShapeType.MultiPointZ);
+
+        // Box
+        WriteF64(buf, 4, -5);
+        WriteF64(buf, 12, 0);
+        WriteF64(buf, 20, 10);
+        WriteF64(buf, 28, 10);
+
+        WriteI32(buf, 36, 3); // NumPoints
+
+        var pointsOffset = 40;
+        WriteXY(0, 0, 0);
+        WriteXY(1, 10, 10);
+        WriteXY(2, -5, 2);
+
+        // Z section begins after XY points
+        var zSection = pointsOffset + 3 * 16;
+        WriteF64(buf, zSection + 0, 1000); // Zmin
+        WriteF64(buf, zSection + 8, 1002); // Zmax
+
+        var zArray = zSection + 16;
+        WriteF64(buf, zArray + 0 * 8, 1000);
+        WriteF64(buf, zArray + 1 * 8, 1001);
+        WriteF64(buf, zArray + 2 * 8, 1002);
+
+        // M section begins after Z array
+        var mSection = zArray + 3 * 8;
+        WriteF64(buf, mSection + 0, 2000); // Mmin
+        WriteF64(buf, mSection + 8, 2002); // Mmax
+
+        var mArray = mSection + 16;
+        WriteF64(buf, mArray + 0 * 8, 2000);
+        WriteF64(buf, mArray + 1 * 8, 2001);
+        WriteF64(buf, mArray + 2 * 8, 2002);
+
+        var mp = MultiPointSerializer.Deserialize(buf);
+
+        Assert.Equal(3, mp.Points.Length);
+        AssertPoint(mp.Points[0], 0, 0, 1000, 2000);
+        AssertPoint(mp.Points[1], 10, 10, 1001, 2001);
+        AssertPoint(mp.Points[2], -5, 2, 1002, 2002);
+
+        void WriteXY(int index, double x, double y)
+        {
+            WriteF64(buf, pointsOffset + index * 16 + 0, x);
+            WriteF64(buf, pointsOffset + index * 16 + 8, y);
+        }
+    }
+
+    // --- Serialize layout tests (will fail until MultiPointSerializer.Serialize exists) ---
+
+    [Fact]
+    public void Serialize_MultiPoint_WritesSpecLayout_PerSpec()
+    {
+        var mp = MakeMultiPointXY();
+        var buf = new byte[88];
+
+        MultiPointSerializer.Serialize(buf, mp);
+
+        Assert.Equal((int)ShapeType.MultiPoint, ReadI32(buf, 0));
+
+        // Box should match points: (-5,0) to (10,10)
+        Assert.Equal(-5, ReadF64(buf, 4));
+        Assert.Equal(0, ReadF64(buf, 12));
+        Assert.Equal(10, ReadF64(buf, 20));
+        Assert.Equal(10, ReadF64(buf, 28));
+
+        Assert.Equal(3, ReadI32(buf, 36)); // NumPoints
+
+        var pointsOffset = 40;
+        AssertXY(0, 0, 0);
+        AssertXY(1, 10, 10);
+        AssertXY(2, -5, 2);
+
+        void AssertXY(int index, double x, double y)
+        {
+            Assert.Equal(x, ReadF64(buf, pointsOffset + index * 16 + 0));
+            Assert.Equal(y, ReadF64(buf, pointsOffset + index * 16 + 8));
+        }
+    }
+
+    [Fact]
+    public void Serialize_MultiPointM_WritesMSectionAfterXY_PerSpec()
+    {
+        var mp = MakeMultiPointM();
+        var buf = new byte[128];
+
+        MultiPointSerializer.Serialize(buf, mp);
+
+        Assert.Equal((int)ShapeType.MultiPointM, ReadI32(buf, 0));
+        Assert.Equal(3, ReadI32(buf, 36));
+
+        var pointsOffset = 40;
+        var mSection = pointsOffset + 3 * 16;
+
+        Assert.Equal(100, ReadF64(buf, mSection + 0)); // Mmin
+        Assert.Equal(102, ReadF64(buf, mSection + 8)); // Mmax
+
+        var mArray = mSection + 16;
+        Assert.Equal(100, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(101, ReadF64(buf, mArray + 1 * 8));
+        Assert.Equal(102, ReadF64(buf, mArray + 2 * 8));
+    }
+
+    [Fact]
+    public void Serialize_MultiPointZ_WritesZThenMSections_PerSpec()
+    {
+        var mp = MakeMultiPointZ();
+        var buf = new byte[168];
+
+        MultiPointSerializer.Serialize(buf, mp);
+
+        Assert.Equal((int)ShapeType.MultiPointZ, ReadI32(buf, 0));
+        Assert.Equal(3, ReadI32(buf, 36));
+
+        var pointsOffset = 40;
+
+        var zSection = pointsOffset + 3 * 16;
+        Assert.Equal(1000, ReadF64(buf, zSection + 0)); // Zmin
+        Assert.Equal(1002, ReadF64(buf, zSection + 8)); // Zmax
+
+        var zArray = zSection + 16;
+        Assert.Equal(1000, ReadF64(buf, zArray + 0 * 8));
+        Assert.Equal(1002, ReadF64(buf, zArray + 2 * 8));
+
+        var mSection = zArray + 3 * 8;
+        Assert.Equal(2000, ReadF64(buf, mSection + 0)); // Mmin
+        Assert.Equal(2002, ReadF64(buf, mSection + 8)); // Mmax
+
+        var mArray = mSection + 16;
+        Assert.Equal(2000, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(2002, ReadF64(buf, mArray + 2 * 8));
+    }
+
+    // ----- model builders (adapt to your actual constructors/properties) -----
+
+    private static MultiPoint MakeMultiPointXY()
+        => new(
+            ImmutableArray.Create(
+                new Point(0, 0),
+                new Point(10, 10),
+                new Point(-5, 2)));
+
+    private static MultiPoint MakeMultiPointM()
+        => new(
+            ImmutableArray.Create(
+                new Point(0, 0, NumericLimits.NoValue, 100),
+                new Point(10, 10, NumericLimits.NoValue, 101),
+                new Point(-5, 2, NumericLimits.NoValue, 102)));
+
+    private static MultiPoint MakeMultiPointZ()
+        => new(
+            ImmutableArray.Create(
+                new Point(0, 0, 1000, 2000),
+                new Point(10, 10, 1001, 2001),
+                new Point(-5, 2, 1002, 2002)));
+
+    private static void AssertPoint(Point p, double x, double y, double z, double m)
+    {
+        Assert.Equal(x, p.X);
+        Assert.Equal(y, p.Y);
+        Assert.Equal(z, p.Z);
+        Assert.Equal(m, p.M);
+    }
+}

--- a/tests/Shape.Tests/Serialization/PointSerializerTests.cs
+++ b/tests/Shape.Tests/Serialization/PointSerializerTests.cs
@@ -1,0 +1,126 @@
+﻿using Shape.Geometries;
+using Shape.Serialization;
+
+namespace Shape.Tests.Serialization;
+
+public sealed class PointSerializerTests : SerializerTests
+{
+    [Fact]
+    public void Deserialize_NullShape_RecordContents_IsJustShapeType()
+    {
+        // Spec: Null shape record contents: only shape type at byte 0. Size = 4 bytes.
+        var buf = new byte[4];
+        WriteI32(buf, 0, (int)ShapeType.Null);
+
+        var p = PointSerializer.Deserialize(buf);
+
+        Assert.Equal(Point.Empty, p);
+    }
+
+    [Fact]
+    public void Deserialize_Point_RecordContents_XY_AtOffsets4And12()
+    {
+        // Spec Table 4: Point: type=1, X at 4, Y at 12. Size = 20 bytes.
+        var buf = new byte[20];
+        WriteI32(buf, 0, (int)ShapeType.Point);
+        WriteF64(buf, 4, 1.25);
+        WriteF64(buf, 12, -2.5);
+
+        var p = PointSerializer.Deserialize(buf);
+
+        Assert.Equal(ShapeType.Point, p.ShapeType);
+        Assert.Equal(1.25, p.X);
+        Assert.Equal(-2.5, p.Y);
+        Assert.False(p.HasZ);
+        Assert.False(p.HasM);
+    }
+
+    [Fact]
+    public void Deserialize_PointM_RecordContents_M_AtOffset20()
+    {
+        // Spec Table 8: PointM: type=21, X at 4, Y at 12, M at 20. Size = 28 bytes.
+        var buf = new byte[28];
+        WriteI32(buf, 0, (int)ShapeType.PointM);
+        WriteF64(buf, 4, 7);
+        WriteF64(buf, 12, 9);
+        WriteF64(buf, 20, 123.456);
+
+        var p = PointSerializer.Deserialize(buf);
+
+        Assert.Equal(ShapeType.PointM, p.ShapeType);
+        Assert.Equal(7, p.X);
+        Assert.Equal(9, p.Y);
+        Assert.False(p.HasZ);
+        Assert.True(p.HasM);
+        Assert.Equal(123.456, p.M);
+    }
+
+    [Fact]
+    public void Deserialize_PointZ_RecordContents_Z_At20_AndM_At28()
+    {
+        // Spec Table 12: PointZ: type=11, X at 4, Y at 12, Z at 20, M at 28. Size = 36 bytes.
+        var buf = new byte[36];
+        WriteI32(buf, 0, (int)ShapeType.PointZ);
+        WriteF64(buf, 4, 10);
+        WriteF64(buf, 12, 20);
+        WriteF64(buf, 20, 30);
+        WriteF64(buf, 28, 40);
+
+        var p = PointSerializer.Deserialize(buf);
+
+        Assert.Equal(ShapeType.PointZ, p.ShapeType);
+        Assert.Equal(10, p.X);
+        Assert.Equal(20, p.Y);
+        Assert.True(p.HasZ);
+        Assert.True(p.HasM);
+        Assert.Equal(30, p.Z);
+        Assert.Equal(40, p.M);
+    }
+
+    [Fact]
+    public void Serialize_Point_RecordContents_WritesShapeTypeXy()
+    {
+        // Spec: Point record contents length is 20 bytes. X at 4, Y at 12.
+        var buf = new byte[20];
+        var p = new Point(1.25, -2.5);
+
+        PointSerializer.Serialize(buf, p);
+
+        Assert.Equal((int)ShapeType.Point, ReadI32(buf, 0));
+        Assert.Equal(1.25, ReadF64(buf, 4));
+        Assert.Equal(-2.5, ReadF64(buf, 12));
+    }
+
+    [Fact]
+    public void Serialize_PointM_RecordContents_M_MustBeAtOffset20_PerSpec()
+    {
+        // Spec: PointM stores M at byte 20 (not 28). Record contents length is 28 bytes.
+        var buf = new byte[28];
+        var p = new Point(7, 9, 123.456);
+
+        PointSerializer.Serialize(buf, p);
+
+        Assert.Equal(ShapeType.PointM, (ShapeType)ReadI32(buf, 0));
+        Assert.Equal(7, ReadF64(buf, 4));
+        Assert.Equal(9, ReadF64(buf, 12));
+
+        // This is the spec requirement:
+        Assert.Equal(123.456, ReadF64(buf, 20));
+    }
+
+    [Fact]
+    public void Serialize_PointZ_RecordContents_Z_At20_AndM_At28_PerSpec()
+    {
+        // Spec: PointZ stores Z at 20 and M at 28. Record contents length is 36 bytes.
+        var buf = new byte[36];
+        var p = new Point(10, 20, 30, 40);
+
+        PointSerializer.Serialize(buf, p);
+
+        Assert.Equal((int)ShapeType.PointZ, ReadI32(buf, 0));
+        Assert.Equal(10, ReadF64(buf, 4));
+        Assert.Equal(20, ReadF64(buf, 12));
+        Assert.Equal(30, ReadF64(buf, 20));
+        Assert.Equal(40, ReadF64(buf, 28));
+    }
+}

--- a/tests/Shape.Tests/Serialization/PolyLineSerializerTests.cs
+++ b/tests/Shape.Tests/Serialization/PolyLineSerializerTests.cs
@@ -1,0 +1,380 @@
+﻿using System.Buffers.Binary;
+using System.Collections.Immutable;
+using Shape.Geometries;
+using Shape.Serialization;
+
+namespace Shape.Tests.Serialization;
+
+public sealed class PolyLineSerializerTests : SerializerTests
+{
+    [Fact]
+    public void Deserialize_Null_ReturnsEmpty()
+    {
+        var buf = new byte[4];
+        WriteI32(buf, 0, (int)ShapeType.Null);
+
+        var pl = PolyLineSerializer.Deserialize(buf);
+
+        Assert.Equal(PolyLine.Empty, pl);
+    }
+
+    [Fact]
+    public void Deserialize_PolyLine_TwoParts_ReadsPartsAndPoints_PerSpec()
+    {
+        // Parts:
+        //  - Part 0: (0,0), (1,1), (2,0)
+        //  - Part 1: (10,10), (11,11)
+        // NumParts=2, NumPoints=5, Parts=[0,3]
+        //
+        // Record contents size (bytes):
+        // 4 (type) + 32 (box) + 4 + 4 + (2*4) + (5*16) = 132
+        var buf = new byte[132];
+
+        // Header
+        WriteI32(buf, 0, (int)ShapeType.PolyLine);
+
+        // Box (Xmin, Ymin, Xmax, Ymax)
+        WriteF64(buf, 4, 0); // Xmin
+        WriteF64(buf, 12, 0); // Ymin
+        WriteF64(buf, 20, 11); // Xmax
+        WriteF64(buf, 28, 11); // Ymax
+
+        // NumParts, NumPoints
+        WriteI32(buf, 36, 2);
+        WriteI32(buf, 40, 5);
+
+        // Parts array @ 44
+        WriteI32(buf, 44, 0);
+        WriteI32(buf, 48, 3);
+
+        // Points array starts at 44 + NumParts*4 = 52
+        // Each point is 16 bytes: X(double), Y(double)
+        var pointsOffset = 52;
+
+        // p0
+        WriteF64(buf, pointsOffset + 0 * 16 + 0, 0);
+        WriteF64(buf, pointsOffset + 0 * 16 + 8, 0);
+
+        // p1
+        WriteF64(buf, pointsOffset + 1 * 16 + 0, 1);
+        WriteF64(buf, pointsOffset + 1 * 16 + 8, 1);
+
+        // p2
+        WriteF64(buf, pointsOffset + 2 * 16 + 0, 2);
+        WriteF64(buf, pointsOffset + 2 * 16 + 8, 0);
+
+        // p3
+        WriteF64(buf, pointsOffset + 3 * 16 + 0, 10);
+        WriteF64(buf, pointsOffset + 3 * 16 + 8, 10);
+
+        // p4
+        WriteF64(buf, pointsOffset + 4 * 16 + 0, 11);
+        WriteF64(buf, pointsOffset + 4 * 16 + 8, 11);
+
+        var pl = PolyLineSerializer.Deserialize(buf);
+
+        Assert.Equal(2, pl.Lines.Length);
+
+        var ls0 = pl.Lines[0];
+        Assert.Equal(3, ls0.Points.Length);
+        AssertPoint(ls0.Points[0], 0, 0, NumericLimits.NoValue, NumericLimits.NoValue);
+        AssertPoint(ls0.Points[1], 1, 1, NumericLimits.NoValue, NumericLimits.NoValue);
+        AssertPoint(ls0.Points[2], 2, 0, NumericLimits.NoValue, NumericLimits.NoValue);
+
+        var ls1 = pl.Lines[1];
+        Assert.Equal(2, ls1.Points.Length);
+        AssertPoint(ls1.Points[0], 10, 10, NumericLimits.NoValue, NumericLimits.NoValue);
+        AssertPoint(ls1.Points[1], 11, 11, NumericLimits.NoValue, NumericLimits.NoValue);
+    }
+
+    [Fact]
+    public void Deserialize_PolyLineM_ReadsMArray_PerSpec()
+    {
+        // Same geometry as above, plus Mmin/Mmax + Marray[5].
+        // Size = PolyLine(132) + 16 + (5*8)=40 => 188
+        var buf = new byte[188];
+
+        WriteI32(buf, 0, (int)ShapeType.PolyLineM);
+
+        // Box
+        WriteF64(buf, 4, 0);
+        WriteF64(buf, 12, 0);
+        WriteF64(buf, 20, 11);
+        WriteF64(buf, 28, 11);
+
+        WriteI32(buf, 36, 2); // NumParts
+        WriteI32(buf, 40, 5); // NumPoints
+
+        WriteI32(buf, 44, 0);
+        WriteI32(buf, 48, 3);
+
+        var pointsOffset = 52;
+        WriteXY(pointsOffset, 0, 0, 0);
+        WriteXY(pointsOffset, 1, 1, 1);
+        WriteXY(pointsOffset, 2, 2, 0);
+        WriteXY(pointsOffset, 3, 10, 10);
+        WriteXY(pointsOffset, 4, 11, 11);
+
+        // M section starts immediately after XY points:
+        // mMin/mMax at (pointsOffset + NumPoints*16)
+        var mSection = pointsOffset + 5 * 16;
+        WriteF64(buf, mSection + 0, 100); // Mmin
+        WriteF64(buf, mSection + 8, 104); // Mmax
+
+        // M array follows
+        var mArray = mSection + 16;
+        WriteF64(buf, mArray + 0 * 8, 100);
+        WriteF64(buf, mArray + 1 * 8, 101);
+        WriteF64(buf, mArray + 2 * 8, 102);
+        WriteF64(buf, mArray + 3 * 8, 103);
+        WriteF64(buf, mArray + 4 * 8, 104);
+
+        var pl = PolyLineSerializer.Deserialize(buf);
+
+        var ls0 = pl.Lines[0];
+        AssertPoint(ls0.Points[0], 0, 0, NumericLimits.NoValue, 100);
+        AssertPoint(ls0.Points[1], 1, 1, NumericLimits.NoValue, 101);
+        AssertPoint(ls0.Points[2], 2, 0, NumericLimits.NoValue, 102);
+
+        var ls1 = pl.Lines[1];
+        AssertPoint(ls1.Points[0], 10, 10, NumericLimits.NoValue, 103);
+        AssertPoint(ls1.Points[1], 11, 11, NumericLimits.NoValue, 104);
+
+        void WriteXY(int baseOffset, int index, double x, double y)
+        {
+            WriteF64(buf, baseOffset + index * 16 + 0, x);
+            WriteF64(buf, baseOffset + index * 16 + 8, y);
+        }
+    }
+
+    [Fact]
+    public void Deserialize_PolyLineZ_ReadsZAndMArrays_PerSpec()
+    {
+        // Same geometry as above, plus:
+        // Zmin/Zmax + Zarray[5] + Mmin/Mmax + Marray[5]
+        // Size = PolyLine(132) + (16 + 40) + (16 + 40) = 244
+        var buf = new byte[244];
+
+        WriteI32(buf, 0, (int)ShapeType.PolyLineZ);
+
+        // Box
+        WriteF64(buf, 4, 0);
+        WriteF64(buf, 12, 0);
+        WriteF64(buf, 20, 11);
+        WriteF64(buf, 28, 11);
+
+        WriteI32(buf, 36, 2); // NumParts
+        WriteI32(buf, 40, 5); // NumPoints
+
+        WriteI32(buf, 44, 0);
+        WriteI32(buf, 48, 3);
+
+        var partsOffset = 44;
+        var pointsOffset = partsOffset + 2 * 4; // 52
+
+        WriteXY(0, 0, 0);
+        WriteXY(1, 1, 1);
+        WriteXY(2, 2, 0);
+        WriteXY(3, 10, 10);
+        WriteXY(4, 11, 11);
+
+        // Z section begins after XY points
+        var zSection = pointsOffset + 5 * 16;
+        WriteF64(buf, zSection + 0, 1000); // Zmin
+        WriteF64(buf, zSection + 8, 1004); // Zmax
+
+        var zArray = zSection + 16;
+        WriteF64(buf, zArray + 0 * 8, 1000);
+        WriteF64(buf, zArray + 1 * 8, 1001);
+        WriteF64(buf, zArray + 2 * 8, 1002);
+        WriteF64(buf, zArray + 3 * 8, 1003);
+        WriteF64(buf, zArray + 4 * 8, 1004);
+
+        // M section begins after Z array
+        var mSection = zArray + 5 * 8;
+        WriteF64(buf, mSection + 0, 2000); // Mmin
+        WriteF64(buf, mSection + 8, 2004); // Mmax
+
+        var mArray = mSection + 16;
+        WriteF64(buf, mArray + 0 * 8, 2000);
+        WriteF64(buf, mArray + 1 * 8, 2001);
+        WriteF64(buf, mArray + 2 * 8, 2002);
+        WriteF64(buf, mArray + 3 * 8, 2003);
+        WriteF64(buf, mArray + 4 * 8, 2004);
+
+        var pl = PolyLineSerializer.Deserialize(buf);
+
+        var ls0 = pl.Lines[0];
+        AssertPoint(ls0.Points[0], 0, 0, 1000, 2000);
+        AssertPoint(ls0.Points[1], 1, 1, 1001, 2001);
+        AssertPoint(ls0.Points[2], 2, 0, 1002, 2002);
+
+        var ls1 = pl.Lines[1];
+        AssertPoint(ls1.Points[0], 10, 10, 1003, 2003);
+        AssertPoint(ls1.Points[1], 11, 11, 1004, 2004);
+
+        void WriteXY(int index, double x, double y)
+        {
+            WriteF64(buf, pointsOffset + index * 16 + 0, x);
+            WriteF64(buf, pointsOffset + index * 16 + 8, y);
+        }
+    }
+
+    // --- Serialize layout tests (will fail until you implement Serialize) ---
+
+    [Fact]
+    public void Serialize_PolyLine_WritesSpecLayout_TwoParts()
+    {
+        var pl = MakeTwoPartPolyLineXY();
+        var buf = new byte[132];
+
+
+        PolyLineSerializer.Serialize(buf, pl);
+
+        Assert.Equal((int)ShapeType.PolyLine, ReadI32(buf, 0));
+
+        // Box
+        Assert.Equal(0, ReadF64(buf, 4)); // Xmin
+        Assert.Equal(0, ReadF64(buf, 12)); // Ymin
+        Assert.Equal(11, ReadF64(buf, 20)); // Xmax
+        Assert.Equal(11, ReadF64(buf, 28)); // Ymax
+
+        Assert.Equal(2, ReadI32(buf, 36)); // NumParts
+        Assert.Equal(5, ReadI32(buf, 40)); // NumPoints
+
+        // Parts array
+        Assert.Equal(0, ReadI32(buf, 44));
+        Assert.Equal(3, ReadI32(buf, 48));
+
+        // XY array
+        var pointsOffset = 52;
+        AssertXY(buf, pointsOffset, 0, 0, 0);
+        AssertXY(buf, pointsOffset, 1, 1, 1);
+        AssertXY(buf, pointsOffset, 2, 2, 0);
+        AssertXY(buf, pointsOffset, 3, 10, 10);
+        AssertXY(buf, pointsOffset, 4, 11, 11);
+
+        static void AssertXY(byte[] b, int baseOffset, int index, double x, double y)
+        {
+            Assert.Equal(x, BinaryPrimitives.ReadDoubleLittleEndian(b.AsSpan(baseOffset + index * 16 + 0, 8)));
+            Assert.Equal(y, BinaryPrimitives.ReadDoubleLittleEndian(b.AsSpan(baseOffset + index * 16 + 8, 8)));
+        }
+    }
+
+    [Fact]
+    public void Serialize_PolyLineM_WritesMSectionAfterXY_PerSpec()
+    {
+        var pl = MakeTwoPartPolyLineM();
+        var buf = new byte[188];
+
+        PolyLineSerializer.Serialize(buf, pl);
+
+        Assert.Equal((int)ShapeType.PolyLineM, ReadI32(buf, 0));
+        Assert.Equal(2, ReadI32(buf, 36));
+        Assert.Equal(5, ReadI32(buf, 40));
+
+        var pointsOffset = 52;
+        var mSection = pointsOffset + 5 * 16;
+
+        // Mmin/Mmax
+        Assert.Equal(100, ReadF64(buf, mSection + 0));
+        Assert.Equal(104, ReadF64(buf, mSection + 8));
+
+        // M array
+        var mArray = mSection + 16;
+        Assert.Equal(100, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(101, ReadF64(buf, mArray + 1 * 8));
+        Assert.Equal(102, ReadF64(buf, mArray + 2 * 8));
+        Assert.Equal(103, ReadF64(buf, mArray + 3 * 8));
+        Assert.Equal(104, ReadF64(buf, mArray + 4 * 8));
+    }
+
+    [Fact]
+    public void Serialize_PolyLineZ_WritesZThenMSections_PerSpec()
+    {
+        var pl = MakeTwoPartPolyLineZ();
+        var buf = new byte[244];
+
+        PolyLineSerializer.Serialize(buf, pl);
+
+        Assert.Equal((int)ShapeType.PolyLineZ, ReadI32(buf, 0));
+        Assert.Equal(2, ReadI32(buf, 36));
+        Assert.Equal(5, ReadI32(buf, 40));
+
+        var pointsOffset = 52;
+
+        var zSection = pointsOffset + 5 * 16;
+        Assert.Equal(1000, ReadF64(buf, zSection + 0)); // Zmin
+        Assert.Equal(1004, ReadF64(buf, zSection + 8)); // Zmax
+
+        var zArray = zSection + 16;
+        Assert.Equal(1000, ReadF64(buf, zArray + 0 * 8));
+        Assert.Equal(1004, ReadF64(buf, zArray + 4 * 8));
+
+        var mSection = zArray + 5 * 8;
+        Assert.Equal(2000, ReadF64(buf, mSection + 0)); // Mmin
+        Assert.Equal(2004, ReadF64(buf, mSection + 8)); // Mmax
+
+        var mArray = mSection + 16;
+        Assert.Equal(2000, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(2004, ReadF64(buf, mArray + 4 * 8));
+    }
+
+    // ----- helpers for expected model objects -----
+
+    private static PolyLine MakeTwoPartPolyLineXY()
+    {
+        var ls0 = new LineString(
+            ImmutableArray.Create(
+                new Point(0, 0),
+                new Point(1, 1),
+                new Point(2, 0)));
+
+        var ls1 = new LineString(
+            ImmutableArray.Create(
+                new Point(10, 10),
+                new Point(11, 11)));
+
+        return new PolyLine(ImmutableArray.Create(ls0, ls1));
+    }
+
+    private static PolyLine MakeTwoPartPolyLineM()
+    {
+        var ls0 = new LineString(
+            ImmutableArray.Create(
+                new Point(0, 0, NumericLimits.NoValue, 100),
+                new Point(1, 1, NumericLimits.NoValue, 101),
+                new Point(2, 0, NumericLimits.NoValue, 102)));
+
+        var ls1 = new LineString(
+            ImmutableArray.Create(
+                new Point(10, 10, NumericLimits.NoValue, 103),
+                new Point(11, 11, NumericLimits.NoValue, 104)));
+
+        return new PolyLine(ImmutableArray.Create(ls0, ls1));
+    }
+
+    private static PolyLine MakeTwoPartPolyLineZ()
+    {
+        var ls0 = new LineString(
+            ImmutableArray.Create(
+                new Point(0, 0, 1000, 2000),
+                new Point(1, 1, 1001, 2001),
+                new Point(2, 0, 1002, 2002)));
+
+        var ls1 = new LineString(
+            ImmutableArray.Create(
+                new Point(10, 10, 1003, 2003),
+                new Point(11, 11, 1004, 2004)));
+
+        return new PolyLine(ImmutableArray.Create(ls0, ls1));
+    }
+
+    private static void AssertPoint(Point p, double x, double y, double z, double m)
+    {
+        Assert.Equal(x, p.X);
+        Assert.Equal(y, p.Y);
+        Assert.Equal(z, p.Z);
+        Assert.Equal(m, p.M);
+    }
+}

--- a/tests/Shape.Tests/Serialization/PolygonSerializerTests .cs
+++ b/tests/Shape.Tests/Serialization/PolygonSerializerTests .cs
@@ -1,0 +1,390 @@
+﻿using System.Collections.Immutable;
+using Shape.Geometries;
+using Shape.Serialization;
+
+namespace Shape.Tests.Serialization;
+
+public sealed class PolygonSerializerTests : SerializerTests
+{
+    [Fact]
+    public void Deserialize_Null_ReturnsEmpty()
+    {
+        var buf = new byte[4];
+        WriteI32(buf, 0, (int)ShapeType.Null);
+
+        var poly = PolygonSerializer.Deserialize(buf);
+
+        Assert.Equal(Polygon.Empty, poly);
+    }
+
+    [Fact]
+    public void Deserialize_Polygon_TwoRings_OuterAndHole_PerSpec()
+    {
+        // Outer ring: square (0,0)-(10,0)-(10,10)-(0,10)-(0,0)
+        // Inner ring (hole): square (2,2)-(8,2)-(8,8)-(2,8)-(2,2)
+        //
+        // NumParts=2
+        // NumPoints=10 (5 + 5)
+        // Parts=[0,5]
+        //
+        // Record contents size (Polygon XY):
+        // 4 + 32 + 4 + 4 + (2*4) + (10*16) = 4+32+4+4+8+160 = 212
+        var buf = new byte[212];
+
+        WriteI32(buf, 0, (int)ShapeType.Polygon);
+
+        // Box
+        WriteF64(buf, 4, 0); // Xmin
+        WriteF64(buf, 12, 0); // Ymin
+        WriteF64(buf, 20, 10); // Xmax
+        WriteF64(buf, 28, 10); // Ymax
+
+        WriteI32(buf, 36, 2); // NumParts
+        WriteI32(buf, 40, 10); // NumPoints
+
+        // Parts @ 44
+        WriteI32(buf, 44, 0); // outer start
+        WriteI32(buf, 48, 5); // hole start
+
+        var pointsOffset = 52;
+
+        // Outer ring points (5)
+        WriteXY(0, 0, 0);
+        WriteXY(1, 10, 0);
+        WriteXY(2, 10, 10);
+        WriteXY(3, 0, 10);
+        WriteXY(4, 0, 0);
+
+        // Hole ring points (5)
+        WriteXY(5, 2, 2);
+        WriteXY(6, 8, 2);
+        WriteXY(7, 8, 8);
+        WriteXY(8, 2, 8);
+        WriteXY(9, 2, 2);
+
+        var poly = PolygonSerializer.Deserialize(buf);
+
+        Assert.Equal(2, poly.Rings.Length);
+
+        var outer = poly.Rings[0];
+        Assert.Equal(5, outer.Points.Length);
+        AssertPoint(outer.Points[0], 0, 0, NumericLimits.NoValue, NumericLimits.NoValue);
+        AssertPoint(outer.Points[4], 0, 0, NumericLimits.NoValue, NumericLimits.NoValue);
+
+        var hole = poly.Rings[1];
+        Assert.Equal(5, hole.Points.Length);
+        AssertPoint(hole.Points[0], 2, 2, NumericLimits.NoValue, NumericLimits.NoValue);
+        AssertPoint(hole.Points[4], 2, 2, NumericLimits.NoValue, NumericLimits.NoValue);
+
+        void WriteXY(int index, double x, double y)
+        {
+            WriteF64(buf, pointsOffset + index * 16 + 0, x);
+            WriteF64(buf, pointsOffset + index * 16 + 8, y);
+        }
+    }
+
+    [Fact]
+    public void Deserialize_PolygonM_ReadsMArray_PerSpec()
+    {
+        // Same rings as above, plus Mmin/Mmax + Marray[10].
+        // Size = PolygonXY(212) + 16 + (10*8)=80 => 308
+        var buf = new byte[308];
+
+        WriteI32(buf, 0, (int)ShapeType.PolygonM);
+
+        // Box
+        WriteF64(buf, 4, 0);
+        WriteF64(buf, 12, 0);
+        WriteF64(buf, 20, 10);
+        WriteF64(buf, 28, 10);
+
+        WriteI32(buf, 36, 2); // NumParts
+        WriteI32(buf, 40, 10); // NumPoints
+
+        WriteI32(buf, 44, 0);
+        WriteI32(buf, 48, 5);
+
+        var pointsOffset = 52;
+
+        // Outer ring
+        WriteXY(0, 0, 0);
+        WriteXY(1, 10, 0);
+        WriteXY(2, 10, 10);
+        WriteXY(3, 0, 10);
+        WriteXY(4, 0, 0);
+
+        // Hole ring
+        WriteXY(5, 2, 2);
+        WriteXY(6, 8, 2);
+        WriteXY(7, 8, 8);
+        WriteXY(8, 2, 8);
+        WriteXY(9, 2, 2);
+
+        // M section after XY points
+        var mSection = pointsOffset + 10 * 16;
+        WriteF64(buf, mSection + 0, 100); // Mmin
+        WriteF64(buf, mSection + 8, 109); // Mmax
+
+        var mArray = mSection + 16;
+        for (var i = 0; i < 10; i++)
+            WriteF64(buf, mArray + i * 8, 100 + i);
+
+        var poly = PolygonSerializer.Deserialize(buf);
+
+        // Spot-check Ms on a few points
+        Assert.Equal(100, poly.Rings[0].Points[0].M);
+        Assert.Equal(104, poly.Rings[0].Points[4].M);
+        Assert.Equal(105, poly.Rings[1].Points[0].M);
+        Assert.Equal(109, poly.Rings[1].Points[4].M);
+
+        void WriteXY(int index, double x, double y)
+        {
+            WriteF64(buf, pointsOffset + index * 16 + 0, x);
+            WriteF64(buf, pointsOffset + index * 16 + 8, y);
+        }
+    }
+
+    [Fact]
+    public void Deserialize_PolygonZ_ReadsZThenMSections_PerSpec()
+    {
+        // Same rings as above, plus:
+        // Zmin/Zmax + Zarray[10] + Mmin/Mmax + Marray[10]
+        // Size = PolygonXY(212) + (16 + 10*8=80) + (16 + 10*8=80) = 212 + 96 + 96 = 404
+        var buf = new byte[404];
+
+        WriteI32(buf, 0, (int)ShapeType.PolygonZ);
+
+        // Box
+        WriteF64(buf, 4, 0);
+        WriteF64(buf, 12, 0);
+        WriteF64(buf, 20, 10);
+        WriteF64(buf, 28, 10);
+
+        WriteI32(buf, 36, 2);
+        WriteI32(buf, 40, 10);
+
+        WriteI32(buf, 44, 0);
+        WriteI32(buf, 48, 5);
+
+        var pointsOffset = 52;
+
+        // XY points (10)
+        WriteXY(0, 0, 0);
+        WriteXY(1, 10, 0);
+        WriteXY(2, 10, 10);
+        WriteXY(3, 0, 10);
+        WriteXY(4, 0, 0);
+
+        WriteXY(5, 2, 2);
+        WriteXY(6, 8, 2);
+        WriteXY(7, 8, 8);
+        WriteXY(8, 2, 8);
+        WriteXY(9, 2, 2);
+
+        // Z section
+        var zSection = pointsOffset + 10 * 16;
+        WriteF64(buf, zSection + 0, 1000); // Zmin
+        WriteF64(buf, zSection + 8, 1009); // Zmax
+
+        var zArray = zSection + 16;
+        for (var i = 0; i < 10; i++)
+            WriteF64(buf, zArray + i * 8, 1000 + i);
+
+        // M section
+        var mSection = zArray + 10 * 8;
+        WriteF64(buf, mSection + 0, 2000); // Mmin
+        WriteF64(buf, mSection + 8, 2009); // Mmax
+
+        var mArray = mSection + 16;
+        for (var i = 0; i < 10; i++)
+            WriteF64(buf, mArray + i * 8, 2000 + i);
+
+        var poly = PolygonSerializer.Deserialize(buf);
+
+        // Spot-check Z/M at a few indices across rings
+        AssertPoint(poly.Rings[0].Points[0], 0, 0, 1000, 2000);
+        AssertPoint(poly.Rings[0].Points[4], 0, 0, 1004, 2004);
+        AssertPoint(poly.Rings[1].Points[0], 2, 2, 1005, 2005);
+        AssertPoint(poly.Rings[1].Points[4], 2, 2, 1009, 2009);
+
+        void WriteXY(int index, double x, double y)
+        {
+            WriteF64(buf, pointsOffset + index * 16 + 0, x);
+            WriteF64(buf, pointsOffset + index * 16 + 8, y);
+        }
+    }
+
+    // --- Serialize layout tests (will fail until you implement PolygonSerializer.Serialize) ---
+
+    [Fact]
+    public void Serialize_Polygon_WritesSpecLayout_OuterAndHole()
+    {
+        var poly = MakeOuterAndHoleXY();
+        var buf = new byte[212];
+
+        PolygonSerializer.Serialize(buf, poly);
+
+        Assert.Equal((int)ShapeType.Polygon, ReadI32(buf, 0));
+
+        // Box
+        Assert.Equal(0, ReadF64(buf, 4));
+        Assert.Equal(0, ReadF64(buf, 12));
+        Assert.Equal(10, ReadF64(buf, 20));
+        Assert.Equal(10, ReadF64(buf, 28));
+
+        Assert.Equal(2, ReadI32(buf, 36)); // NumParts
+        Assert.Equal(10, ReadI32(buf, 40)); // NumPoints
+
+        Assert.Equal(0, ReadI32(buf, 44));
+        Assert.Equal(5, ReadI32(buf, 48));
+
+        var pointsOffset = 52;
+
+        AssertXY(0, 0, 0);
+        AssertXY(1, 10, 0);
+        AssertXY(2, 10, 10);
+        AssertXY(3, 0, 10);
+        AssertXY(4, 0, 0);
+
+        AssertXY(5, 2, 2);
+        AssertXY(6, 8, 2);
+        AssertXY(7, 8, 8);
+        AssertXY(8, 2, 8);
+        AssertXY(9, 2, 2);
+
+        void AssertXY(int index, double x, double y)
+        {
+            Assert.Equal(x, ReadF64(buf, pointsOffset + index * 16 + 0));
+            Assert.Equal(y, ReadF64(buf, pointsOffset + index * 16 + 8));
+        }
+    }
+
+    [Fact]
+    public void Serialize_PolygonM_WritesMSectionAfterXY_PerSpec()
+    {
+        var poly = MakeOuterAndHoleM();
+        var buf = new byte[308];
+
+        PolygonSerializer.Serialize(buf, poly);
+
+        Assert.Equal((int)ShapeType.PolygonM, ReadI32(buf, 0));
+        Assert.Equal(2, ReadI32(buf, 36));
+        Assert.Equal(10, ReadI32(buf, 40));
+
+        var pointsOffset = 52;
+        var mSection = pointsOffset + 10 * 16;
+
+        Assert.Equal(100, ReadF64(buf, mSection + 0)); // Mmin
+        Assert.Equal(109, ReadF64(buf, mSection + 8)); // Mmax
+
+        var mArray = mSection + 16;
+        Assert.Equal(100, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(109, ReadF64(buf, mArray + 9 * 8));
+    }
+
+    [Fact]
+    public void Serialize_PolygonZ_WritesZThenMSections_PerSpec()
+    {
+        var poly = MakeOuterAndHoleZ();
+        var buf = new byte[404];
+
+        PolygonSerializer.Serialize(buf, poly);
+
+        Assert.Equal((int)ShapeType.PolygonZ, ReadI32(buf, 0));
+        Assert.Equal(2, ReadI32(buf, 36));
+        Assert.Equal(10, ReadI32(buf, 40));
+
+        var pointsOffset = 52;
+
+        var zSection = pointsOffset + 10 * 16;
+        Assert.Equal(1000, ReadF64(buf, zSection + 0)); // Zmin
+        Assert.Equal(1009, ReadF64(buf, zSection + 8)); // Zmax
+
+        var zArray = zSection + 16;
+        Assert.Equal(1000, ReadF64(buf, zArray + 0 * 8));
+        Assert.Equal(1009, ReadF64(buf, zArray + 9 * 8));
+
+        var mSection = zArray + 10 * 8;
+        Assert.Equal(2000, ReadF64(buf, mSection + 0)); // Mmin
+        Assert.Equal(2009, ReadF64(buf, mSection + 8)); // Mmax
+
+        var mArray = mSection + 16;
+        Assert.Equal(2000, ReadF64(buf, mArray + 0 * 8));
+        Assert.Equal(2009, ReadF64(buf, mArray + 9 * 8));
+    }
+
+    // ----- model builders (adapt names/types to your actual geometry model) -----
+
+    private static Polygon MakeOuterAndHoleXY()
+    {
+        var outer = new LinearRing(
+            ImmutableArray.Create(
+                new Point(0, 0),
+                new Point(10, 0),
+                new Point(10, 10),
+                new Point(0, 10),
+                new Point(0, 0)));
+
+        var hole = new LinearRing(
+            ImmutableArray.Create(
+                new Point(2, 2),
+                new Point(8, 2),
+                new Point(8, 8),
+                new Point(2, 8),
+                new Point(2, 2)));
+
+        return new Polygon(ImmutableArray.Create(outer, hole));
+    }
+
+    private static Polygon MakeOuterAndHoleM()
+    {
+        // M values 100..109 in point order
+        var outer = new LinearRing(
+            ImmutableArray.Create(
+                new Point(0, 0, NumericLimits.NoValue, 100),
+                new Point(10, 0, NumericLimits.NoValue, 101),
+                new Point(10, 10, NumericLimits.NoValue, 102),
+                new Point(0, 10, NumericLimits.NoValue, 103),
+                new Point(0, 0, NumericLimits.NoValue, 104)));
+
+        var hole = new LinearRing(
+            ImmutableArray.Create(
+                new Point(2, 2, NumericLimits.NoValue, 105),
+                new Point(8, 2, NumericLimits.NoValue, 106),
+                new Point(8, 8, NumericLimits.NoValue, 107),
+                new Point(2, 8, NumericLimits.NoValue, 108),
+                new Point(2, 2, NumericLimits.NoValue, 109)));
+
+        return new Polygon(ImmutableArray.Create(outer, hole));
+    }
+
+    private static Polygon MakeOuterAndHoleZ()
+    {
+        // Z values 1000..1009, M values 2000..2009 in point order
+        var outer = new LinearRing(
+            ImmutableArray.Create(
+                new Point(0, 0, 1000, 2000),
+                new Point(10, 0, 1001, 2001),
+                new Point(10, 10, 1002, 2002),
+                new Point(0, 10, 1003, 2003),
+                new Point(0, 0, 1004, 2004)));
+
+        var hole = new LinearRing(
+            ImmutableArray.Create(
+                new Point(2, 2, 1005, 2005),
+                new Point(8, 2, 1006, 2006),
+                new Point(8, 8, 1007, 2007),
+                new Point(2, 8, 1008, 2008),
+                new Point(2, 2, 1009, 2009)));
+
+        return new Polygon(ImmutableArray.Create(outer, hole));
+    }
+
+    private static void AssertPoint(Point p, double x, double y, double z, double m)
+    {
+        Assert.Equal(x, p.X);
+        Assert.Equal(y, p.Y);
+        Assert.Equal(z, p.Z);
+        Assert.Equal(m, p.M);
+    }
+}

--- a/tests/Shape.Tests/Serialization/SerializerTests.cs
+++ b/tests/Shape.Tests/Serialization/SerializerTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Buffers.Binary;
+
+namespace Shape.Tests.Serialization;
+
+public abstract class SerializerTests
+{
+    protected static void WriteI32(byte[] buf, int offset, int value) =>
+        BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(offset, 4), value);
+
+    protected static void WriteF64(byte[] buf, int offset, double value) =>
+        BinaryPrimitives.WriteDoubleLittleEndian(buf.AsSpan(offset, 8), value);
+
+    protected static int ReadI32(byte[] buf, int offset) =>
+        BinaryPrimitives.ReadInt32LittleEndian(buf.AsSpan(offset, 4));
+
+    protected static double ReadF64(byte[] buf, int offset) =>
+        BinaryPrimitives.ReadDoubleLittleEndian(buf.AsSpan(offset, 8));
+}

--- a/tests/Shape.Tests/Shape.Tests.csproj
+++ b/tests/Shape.Tests/Shape.Tests.csproj
@@ -1,21 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Shape.Tests</RootNamespace>
-    <TargetFramework>net9.0</TargetFramework>
-    <!--
-    To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
-      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-
-    To enable the Microsoft Testing Platform native command line experience, add property:
-      <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-
-    For more information on Microsoft Testing Platform support in xUnit.net, please visit:
-      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
-    -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Shape.Tests/UnitTest1.cs
+++ b/tests/Shape.Tests/UnitTest1.cs
@@ -14,12 +14,43 @@ public class UnitTest1
 
         var path = @"D:\Data\railways.shp";
 
-        using var shp = Shapefile.Open(path);
-        foreach (var (geometry, attributes) in shp.EnumerateRecords<PolyLine, Attributes>())
+        var start = Stopwatch.GetTimestamp();
+
         {
-            Debug.WriteLine(geometry);
-            Debug.WriteLine(attributes);
+            using var shp1 = Shapefile.Open(path);
+            foreach (var (geometry, attributes) in shp1)
+            {
+                Debug.WriteLine(geometry);
+                Debug.WriteLine(attributes);
+            }
         }
+
+        Debug.WriteLine(Stopwatch.GetElapsedTime(start));
+        start = Stopwatch.GetTimestamp();
+
+        {
+            using var shp2 = Shapefile.Open<PolyLine>(path);
+            foreach (var (geometry, attributes) in shp2)
+            {
+                Debug.WriteLine(geometry);
+                Debug.WriteLine(attributes);
+            }
+        }
+
+        Debug.WriteLine(Stopwatch.GetElapsedTime(start));
+        start = Stopwatch.GetTimestamp();
+
+
+        {
+            using var shp23 = Shapefile.Open<PolyLine, Attributes>(path);
+            foreach (var (geometry, attributes) in shp23)
+            {
+                Debug.WriteLine(geometry);
+                Debug.WriteLine(attributes);
+            }
+        }
+
+        Debug.WriteLine(Stopwatch.GetElapsedTime(start));
     }
 
     public record Attributes(long Id, string Name, string Type);


### PR DESCRIPTION
Major refactor to support spec-compliant binary serialization and deserialization for all geometry types (Point, PolyLine, Polygon, MultiPoint, MultiPatch). Introduced Shape.Serialization namespace with dedicated serializers and offset helpers. Geometry types now implement IGeometrySerializer<T> and expose ShapeType. Refactored Shapefile and ShapeIndex for generic, type-safe access and writing. Added IShapefile interface. Comprehensive test suite added for all geometry serializers, verifying binary layout and round-trip correctness. Updated to .NET 10.0 and DBase 0.1.0-preview.3. Numerous code cleanups and modern C# 12 idioms applied.